### PR TITLE
fix: add dev script in package.json

### DIFF
--- a/apps/examples/package.json
+++ b/apps/examples/package.json
@@ -3,6 +3,7 @@
 	"version": "0.0.4",
 	"description": "Agent Development Kit for TypeScript with multi-provider LLM support",
 	"scripts": {
+    "start": "tsx ./src/index.ts",
 		"dev": "tsx ./src/index.ts"
 	},
 	"private": true,


### PR DESCRIPTION
- Added missing development script to the `package.json` file, which is required to run the ADK examples.