### PR TITLE
docs: update README

### DIFF
--- a/README.md
+++ b/README.md
@@ -353,14 +353,11 @@ The `apps/examples` directory contains comprehensive examples demonstrating ADK'
    # Interactive menu to select examples
    pnpm dev
    
-   # Or run specific examples directly
-   pnpm dev agent-builder-example    # AgentBuilder patterns (recommended first)
-   pnpm dev simple-agent
-   pnpm dev tool-usage
-   pnpm dev memory-usage
+   # Or
+   pnpm --filter @iqai/examples dev
    ```
 
-The examples demonstrate production-ready patterns and can serve as templates for your own implementations.
+The examples demonstrate production-ready patterns and can serve as templates for your implementations.
 
 ## 📈 Project Status and Roadmap
 

--- a/README.md
+++ b/README.md
@@ -349,6 +349,7 @@ The `apps/examples` directory contains comprehensive examples demonstrating ADK'
 3. **Run examples**:
    ```bash
    cd apps/examples
+   pnpm install
    
    # Interactive menu to select examples
    pnpm dev


### PR DESCRIPTION
- Removed command like `pnpm dev agent-builder-example` which does not support running scripts in a subpackage.
- Added `pnpm install` command before running examples.
- Added `pnpm --filter @iqai/examples start` to run script in subpackage.
- Fix grammar error: removed `own`.