### PR TITLE
refactor: refactor Community & Support section to enhance clarity

### DIFF
--- a/apps/docs/content/docs/get-started/index.mdx
+++ b/apps/docs/content/docs/get-started/index.mdx
@@ -166,30 +166,29 @@ Every code sample in our documentation comes from our [examples](https://github.
 
 ## Community & Support
 
-<Cards>
-  <Card
-    title="📖 Documentation"
-    description="Comprehensive guides and API reference"
-    href="/docs"
-  />
+Join our community for help, discussions, and updates:
 
+<Cards>
   <Card
     title="💻 GitHub"
     description="Source code, issues, and contributions"
-    href="https://github.com/IQAICOM/adk-ts"
+    href="https://github.com/IQAIcom/adk-ts"
   />
-
+  <Card
+    title="💬 Discussions"
+    description="Ask questions, share ideas, and get help"
+    href="https://github.com/IQAIcom/adk-ts/discussions"
+  />
+  {/* <Card
+    title="Discord"
+    description="Join our Discord server for real-time collaboration and support"
+    href="https://discord.gg/your-discord-invite"
+  />
   <Card
     title="🔬 Examples"
     description="Real working examples for common patterns"
-    href="/docs/examples"
-  />
-
-  <Card
-    title="🚀 Samples"
-    description="Complete applications and use cases"
-    href="https://github.com/google/adk-samples"
-  />
+    href="https://github.com/IQAIcom/adk-ts/tree/main/apps/examples"
+  /> */}
 </Cards>
 
 ## Next Steps

--- a/apps/docs/content/docs/index.mdx
+++ b/apps/docs/content/docs/index.mdx
@@ -131,9 +131,29 @@ Ready to dive in? Our documentation covers everything from your first agent to a
   />
 </Cards>
 
-<Callout type="info" title="Community & Support">
+## Community & Support
+
 Join our community for help, discussions, and updates:
-- **GitHub**: Report issues and contribute
-- **Documentation**: Comprehensive guides and API reference
-- **Examples**: Real-world applications and use cases
-</Callout>
+
+<Cards>
+  <Card
+    title="💻 GitHub"
+    description="Source code, issues, and contributions"
+    href="https://github.com/IQAIcom/adk-ts"
+  />
+  <Card
+    title="💬 Discussions"
+    description="Ask questions, share ideas, and get help"
+    href="https://github.com/IQAIcom/adk-ts/discussions"
+  />
+  {/* <Card
+    title="Discord"
+    description="Join our Discord server for real-time collaboration and support"
+    href="https://discord.gg/your-discord-invite"
+  />
+  <Card
+    title="🔬 Examples"
+    description="Real working examples for common patterns"
+    href="https://github.com/IQAIcom/adk-ts/tree/main/apps/examples"
+  /> */}
+</Cards>


### PR DESCRIPTION
On the home page and get started page, the community and support options lacked clickable links for users to explore, and some existing links were unrelated to their sections. This update adds proper navigation by:

- Adding direct links to the GitHub repository and Discussion board
- Ensuring all links are relevant to their respective sections

In the future, link to the Discord server or other community platform can be added