### PR TITLE
Add create-adk-project CLI for scaffolding ADK projects

### DIFF
--- a/.changeset/add-create-adk-project-cli.md
+++ b/.changeset/add-create-adk-project-cli.md
@@ -1,0 +1,11 @@
+---
+"create-adk-project": major
+---
+
+Add create-adk-project CLI tool for scaffolding ADK projects
+
+- Interactive CLI using @clack/prompts for beautiful user experience
+- Support for Hono, Express, and Next.js starter templates
+- Automatic dependency installation option
+- Uses giget for cloning templates from GitHub
+- Includes starter templates with ADK integration and TypeScript support

--- a/apps/docs/content/docs/get-started/installation.mdx
+++ b/apps/docs/content/docs/get-started/installation.mdx
@@ -15,7 +15,47 @@ import { Callout } from 'fumadocs-ui/components/callout';
 - **TypeScript**: v5.3 or higher (optional but recommended)
 </Callout>
 
-## Quick Install
+## Quick Start with CLI
+
+The fastest way to get started is using our CLI tool to create a new project:
+
+<Tabs items={['npm', 'yarn', 'pnpm']}>
+  <Tab value="npm">
+    ```bash
+    npx create-adk-project
+    ```
+  </Tab>
+
+  <Tab value="yarn">
+    ```bash
+    yarn create adk-project
+    ```
+  </Tab>
+
+  <Tab value="pnpm">
+    ```bash
+    pnpm create adk-project
+    ```
+  </Tab>
+</Tabs>
+
+This will:
+- Create a new project with the ADK Agent Starter template
+- Set up TypeScript configuration
+- Install all necessary dependencies
+- Provide example code to get you started
+
+<Callout type="info" title="What's Included">
+The CLI creates a complete project with:
+- Pre-configured TypeScript setup
+- Example agent implementations
+- Environment configuration template
+- Development scripts and tooling
+</Callout>
+
+## Manual Installation
+
+If you prefer to add ADK to an existing project or want more control over the setup:
 
 <Steps>
 
@@ -202,6 +242,7 @@ If you encounter issues:
 
 Now that you have ADK TypeScript installed, you're ready to:
 
+- **New to ADK?** Use `npx create-adk-project` for a complete starter template
 - [Create your first agent](/docs/get-started/quickstart) - Build a simple agent in minutes
 - [Explore examples](/docs/examples) - See real working code
 - [Learn about agents](/docs/agents) - Understand the core concepts

--- a/apps/docs/content/docs/get-started/quickstart.mdx
+++ b/apps/docs/content/docs/get-started/quickstart.mdx
@@ -12,6 +12,14 @@ import { Card } from 'fumadocs-ui/components/card';
 Make sure you have [installed ADK TypeScript](/docs/get-started/installation) before continuing.
 </Callout>
 
+<Callout type="tip" title="Quick Start Alternative">
+Want to skip the manual setup? Use our CLI to create a complete project:
+```bash
+npx create-adk-project
+```
+This creates a project with all the examples below already set up and ready to run!
+</Callout>
+
 ## Your First Agent
 
 Let's start with the simplest possible agent - one that can answer questions:

--- a/apps/docs/content/docs/get-started/quickstart.mdx
+++ b/apps/docs/content/docs/get-started/quickstart.mdx
@@ -12,11 +12,13 @@ import { Card } from 'fumadocs-ui/components/card';
 Make sure you have [installed ADK TypeScript](/docs/get-started/installation) before continuing.
 </Callout>
 
-<Callout type="tip" title="Quick Start Alternative">
+<Callout title="Quick Start Alternative">
 Want to skip the manual setup? Use our CLI to create a complete project:
+
 ```bash
 npx create-adk-project
 ```
+
 This creates a project with all the examples below already set up and ready to run!
 </Callout>
 

--- a/packages/create-adk-project/README.md
+++ b/packages/create-adk-project/README.md
@@ -1,6 +1,6 @@
 # create-adk-project
 
-A CLI tool to quickly create ADK TypeScript projects with different frameworks.
+CLI tool to create ADK TypeScript agent projects with a complete starter template.
 
 ## Usage
 
@@ -15,49 +15,43 @@ npm install -g create-adk-project
 create-adk-project
 ```
 
-## Templates
+## What's Included
 
-- **basic** - Basic ADK project with TypeScript
-- **hono** - ADK project with Hono web framework
-- **express** - ADK project with Express.js framework
-- **nextjs** - ADK project with Next.js framework
-- **fastify** - ADK project with Fastify framework
+The CLI creates a complete ADK agent project with:
 
-## Options
+- **🤖 ADK Agent Starter Template** - Complete agent development environment
+- **📝 TypeScript Configuration** - Pre-configured for modern Node.js development
+- **🛠️ Example Agents** - Working examples to get you started quickly
+- **⚙️ Environment Setup** - Template for API keys and configuration
+- **📦 Development Scripts** - Build, test, and development commands
+- **🔧 Tooling** - ESLint, Prettier, and other development tools
 
-- `--template, -t <template>` - Specify template (basic, hono, express, nextjs, fastify)
-- `--yes, -y` - Skip prompts and use defaults
-- `--version` - Show version number
-- `--help` - Show help
+## Interactive Setup
 
-## Examples
+The CLI will guide you through:
 
-```bash
-# Interactive mode
-npx create-adk-project
+1. **Project Name** - Choose your project directory name
+2. **Framework Selection** - Currently includes ADK Agent Starter
+3. **Dependency Installation** - Automatically installs npm packages
+4. **Environment Setup** - Creates `.env` template file
 
-# Specify project name
-npx create-adk-project my-agent
+## Template Source
 
-# Use specific template
-npx create-adk-project my-agent --template hono
-
-# Skip prompts
-npx create-adk-project my-agent --template basic --yes
-```
-
-## Templates Repository
-
-The templates are stored in a separate repository: [adk-ts-templates](https://github.com/IQAIcom/adk-ts-templates)
+The starter template is maintained at: [adk-agent-starter](https://github.com/IQAIcom/adk-agent-starter)
 
 ## Features
 
 - 🚀 Interactive prompts powered by clack
-- 📦 Multiple framework templates
-- 🎨 Beautiful CLI interface with colors
-- 📋 Package manager selection (npm, pnpm, yarn)
-- ✅ Automatic dependency installation
-- 🔧 Automatic project configuration
+- 🎨 Beautiful CLI interface with ASCII art
+- 📦 Automatic dependency installation
+- ⚡ Fast project scaffolding
+- 🔧 Complete development environment setup
+- 📋 Ready-to-run example code
+
+## Requirements
+
+- Node.js v22.0 or higher
+- npm, yarn, or pnpm
 
 ## License
 

--- a/packages/create-adk-project/README.md
+++ b/packages/create-adk-project/README.md
@@ -32,7 +32,7 @@ The CLI will guide you through:
 
 1. **Project Name** - Choose your project directory name
 2. **Framework Selection** - Currently includes ADK Agent Starter
-3. **Dependency Installation** - Automatically installs npm packages
+3. **Dependency Installation** - Choose from available package managers (npm, pnpm, yarn, bun)
 4. **Environment Setup** - Creates `.env` template file
 
 ## Template Source
@@ -43,7 +43,7 @@ The starter template is maintained at: [adk-agent-starter](https://github.com/IQ
 
 - 🚀 Interactive prompts powered by clack
 - 🎨 Beautiful CLI interface with ASCII art
-- 📦 Automatic dependency installation
+- 📦 Smart package manager detection (npm, pnpm, yarn, bun)
 - ⚡ Fast project scaffolding
 - 🔧 Complete development environment setup
 - 📋 Ready-to-run example code

--- a/packages/create-adk-project/README.md
+++ b/packages/create-adk-project/README.md
@@ -1,0 +1,64 @@
+# create-adk-project
+
+A CLI tool to quickly create ADK TypeScript projects with different frameworks.
+
+## Usage
+
+```bash
+npx create-adk-project
+```
+
+Or install globally:
+
+```bash
+npm install -g create-adk-project
+create-adk-project
+```
+
+## Templates
+
+- **basic** - Basic ADK project with TypeScript
+- **hono** - ADK project with Hono web framework
+- **express** - ADK project with Express.js framework
+- **nextjs** - ADK project with Next.js framework
+- **fastify** - ADK project with Fastify framework
+
+## Options
+
+- `--template, -t <template>` - Specify template (basic, hono, express, nextjs, fastify)
+- `--yes, -y` - Skip prompts and use defaults
+- `--version` - Show version number
+- `--help` - Show help
+
+## Examples
+
+```bash
+# Interactive mode
+npx create-adk-project
+
+# Specify project name
+npx create-adk-project my-agent
+
+# Use specific template
+npx create-adk-project my-agent --template hono
+
+# Skip prompts
+npx create-adk-project my-agent --template basic --yes
+```
+
+## Templates Repository
+
+The templates are stored in a separate repository: [adk-ts-templates](https://github.com/IQAIcom/adk-ts-templates)
+
+## Features
+
+- 🚀 Interactive prompts powered by clack
+- 📦 Multiple framework templates
+- 🎨 Beautiful CLI interface with colors
+- 📋 Package manager selection (npm, pnpm, yarn)
+- ✅ Automatic dependency installation
+- 🔧 Automatic project configuration
+
+## License
+
+MIT

--- a/packages/create-adk-project/package.json
+++ b/packages/create-adk-project/package.json
@@ -1,0 +1,52 @@
+{
+	"name": "create-adk-project",
+	"version": "0.1.0",
+	"description": "CLI tool to create ADK TypeScript projects with different frameworks",
+	"main": "dist/index.js",
+	"types": "dist/index.d.ts",
+	"type": "module",
+	"bin": {
+		"create-adk-project": "dist/index.js"
+	},
+	"scripts": {
+		"build": "tsup",
+		"dev": "tsup --watch",
+		"test": "vitest run"
+	},
+	"repository": {
+		"type": "git",
+		"url": "https://github.com/IQAIcom/adk-ts.git"
+	},
+	"keywords": ["ai", "llm", "agent", "cli", "typescript", "create-project"],
+	"author": "IQAI",
+	"license": "MIT",
+	"dependencies": {
+		"@clack/prompts": "^0.7.0",
+		"giget": "^1.2.3",
+		"chalk": "^5.4.1",
+		"dedent": "^1.6.0"
+	},
+	"devDependencies": {
+		"@iqai/tsconfig": "workspace:*",
+		"@types/node": "^20.17.30",
+		"tsup": "^8.4.0",
+		"typescript": "^5.3.2",
+		"vitest": "^3.1.3"
+	},
+	"packageManager": "pnpm@9.0.0",
+	"engines": {
+		"node": ">=22.0"
+	},
+	"files": [
+		"dist",
+		"templates",
+		"!**/*.test.*",
+		"!**/*.json",
+		"CHANGELOG.md",
+		"LICENSE",
+		"README.md"
+	],
+	"publishConfig": {
+		"access": "public"
+	}
+}

--- a/packages/create-adk-project/src/index.ts
+++ b/packages/create-adk-project/src/index.ts
@@ -84,7 +84,7 @@ async function main() {
 	}
 
 	const framework = await select({
-		message: "Which framework would you like to use?",
+		message: "Which template would you like to use?",
 		options: starters,
 	});
 
@@ -93,7 +93,7 @@ async function main() {
 		process.exit(0);
 	}
 
-	const selectedStarter = starters.find(s => s.value === framework);
+	const selectedStarter = starters.find((s) => s.value === framework);
 	if (!selectedStarter) {
 		outro("Invalid starter selected");
 		process.exit(1);
@@ -112,11 +112,11 @@ async function main() {
 	let selectedPackageManager: PackageManager | undefined;
 	if (installDeps) {
 		const availablePackageManagers = await detectAvailablePackageManagers();
-		
+
 		if (availablePackageManagers.length > 1) {
 			const pmChoice = await select({
 				message: "Which package manager would you like to use?",
-				options: availablePackageManagers.map(pm => ({
+				options: availablePackageManagers.map((pm) => ({
 					value: pm.name,
 					label: pm.label,
 					hint: `Use ${pm.command} for dependency management`,
@@ -128,7 +128,9 @@ async function main() {
 				process.exit(0);
 			}
 
-			selectedPackageManager = availablePackageManagers.find(pm => pm.name === pmChoice);
+			selectedPackageManager = availablePackageManagers.find(
+				(pm) => pm.name === pmChoice,
+			);
 		} else {
 			selectedPackageManager = availablePackageManagers[0];
 		}
@@ -156,16 +158,24 @@ async function main() {
 			const { spawn } = await import("node:child_process");
 
 			await new Promise<void>((resolve, reject) => {
-				const child = spawn(selectedPackageManager.command, selectedPackageManager.args, {
-					cwd: targetDir,
-					stdio: "pipe",
-				});
+				const child = spawn(
+					selectedPackageManager.command,
+					selectedPackageManager.args,
+					{
+						cwd: targetDir,
+						stdio: "pipe",
+					},
+				);
 
 				child.on("close", (code) => {
 					if (code === 0) {
 						resolve();
 					} else {
-						reject(new Error(`${selectedPackageManager.command} ${selectedPackageManager.args.join(" ")} failed with code ${code}`));
+						reject(
+							new Error(
+								`${selectedPackageManager.command} ${selectedPackageManager.args.join(" ")} failed with code ${code}`,
+							),
+						);
 					}
 				});
 
@@ -187,13 +197,23 @@ async function main() {
     `),
 		);
 
-		const runCommand = selectedPackageManager?.name === "npm" ? "npm run dev" : 
-						   selectedPackageManager?.name === "yarn" ? "yarn dev" :
-						   selectedPackageManager?.name === "pnpm" ? "pnpm dev" :
-						   selectedPackageManager?.name === "bun" ? "bun run dev" : "npm run dev";
+		const runCommand =
+			selectedPackageManager?.name === "npm"
+				? "npm run dev"
+				: selectedPackageManager?.name === "yarn"
+					? "yarn dev"
+					: selectedPackageManager?.name === "pnpm"
+						? "pnpm dev"
+						: selectedPackageManager?.name === "bun"
+							? "bun run dev"
+							: "npm run dev";
 
-		const installCommand = selectedPackageManager?.name === "yarn" ? "yarn" :
-							   selectedPackageManager ? `${selectedPackageManager.command} ${selectedPackageManager.args.join(" ")}` : "npm install";
+		const installCommand =
+			selectedPackageManager?.name === "yarn"
+				? "yarn"
+				: selectedPackageManager
+					? `${selectedPackageManager.command} ${selectedPackageManager.args.join(" ")}`
+					: "npm install";
 
 		outro(
 			chalk.cyan(

--- a/packages/create-adk-project/src/index.ts
+++ b/packages/create-adk-project/src/index.ts
@@ -1,0 +1,148 @@
+import { existsSync } from "node:fs";
+import { join } from "node:path";
+import { confirm, intro, outro, select, spinner, text } from "@clack/prompts";
+import chalk from "chalk";
+import dedent from "dedent";
+import { downloadTemplate } from "giget";
+import { starters } from "./starters";
+
+async function main() {
+	console.clear();
+
+	// Cool ASCII art intro
+	console.log(
+		chalk.magentaBright(dedent`
+    ╔══════════════════════════════════════════════════════╗
+    ║                                                      ║
+    ║     █████╗ ██████╗ ██╗  ██╗    ████████╗███████╗     ║
+    ║    ██╔══██╗██╔══██╗██║ ██╔╝    ╚══██╔══╝██╔════╝     ║
+    ║    ███████║██║  ██║█████╔╝        ██║   ███████╗     ║
+    ║    ██╔══██║██║  ██║██╔═██╗        ██║   ╚════██║     ║
+    ║    ██║  ██║██████╔╝██║  ██╗       ██║   ███████║     ║
+    ║    ╚═╝  ╚═╝╚═════╝ ╚═╝  ╚═╝       ╚═╝   ╚══════╝     ║
+    ║                                                      ║
+    ╚══════════════════════════════════════════════════════╝
+  `),
+	);
+
+	intro(chalk.bgMagenta.bold(" ✨ Let's build something amazing! "));
+
+	const projectName = await text({
+		message: "What is your project name?",
+		placeholder: "my-adk-project",
+		validate: (value) => {
+			if (!value) return "Project name is required";
+			if (value.includes(" ")) return "Project name cannot contain spaces";
+			if (existsSync(value)) return `Directory "${value}" already exists`;
+			return undefined;
+		},
+	});
+
+	if (typeof projectName === "symbol") {
+		outro("Operation cancelled");
+		process.exit(0);
+	}
+
+	const framework = await select({
+		message: "Which framework would you like to use?",
+		options: starters,
+	});
+
+	if (typeof framework === "symbol") {
+		outro("Operation cancelled");
+		process.exit(0);
+	}
+
+	const selectedStarter = starters.find(s => s.value === framework);
+	if (!selectedStarter) {
+		outro("Invalid starter selected");
+		process.exit(1);
+	}
+
+	const installDeps = await confirm({
+		message: "Install dependencies?",
+		initialValue: true,
+	});
+
+	if (typeof installDeps === "symbol") {
+		outro("Operation cancelled");
+		process.exit(0);
+	}
+
+	const s = spinner();
+
+	try {
+		s.start("Creating project...");
+
+		const templatePath = selectedStarter.template;
+		const targetDir = join(process.cwd(), projectName);
+
+		await downloadTemplate(templatePath, {
+			dir: targetDir,
+			offline: false,
+			preferOffline: false,
+		});
+
+		s.stop("Project created successfully!");
+
+		if (installDeps) {
+			s.start("Installing dependencies...");
+
+			const { spawn } = await import("node:child_process");
+
+			await new Promise<void>((resolve, reject) => {
+				const child = spawn("npm", ["install"], {
+					cwd: targetDir,
+					stdio: "pipe",
+				});
+
+				child.on("close", (code) => {
+					if (code === 0) {
+						resolve();
+					} else {
+						reject(new Error(`npm install failed with code ${code}`));
+					}
+				});
+
+				child.on("error", reject);
+			});
+
+			s.stop("Dependencies installed!");
+		}
+
+		const envFile = ".env";
+
+		console.log(
+			chalk.green(`
+    ╔═══════════════════════════════════════════════════════════════╗
+    ║                                                               ║
+    ║  ${chalk.bold.yellow("🎉 SUCCESS!")} Your ADK project has been created!           ║
+    ║                                                               ║
+    ╚═══════════════════════════════════════════════════════════════╝
+    `),
+		);
+
+		outro(
+			chalk.cyan(
+				dedent`
+          ${chalk.bold("🚀 Next steps:")}
+
+            ${chalk.yellow("1.")} ${chalk.bold(`cd ${projectName}`)}
+            ${installDeps ? "" : `${chalk.yellow("2.")} ${chalk.bold("npm install")}`}
+            ${chalk.yellow(installDeps ? "2." : "3.")} ${chalk.bold(`cp .env.example ${envFile}`)}
+            ${chalk.yellow(installDeps ? "3." : "4.")} ${chalk.gray(`# Add your API keys to the ${envFile} file`)}
+            ${chalk.yellow(installDeps ? "4." : "5.")} ${chalk.bold("npm run dev")}
+
+          ${chalk.bold.green("🤖 Your AI agent is ready to go!")}
+          ${chalk.gray("Documentation: https://docs.iqai.com")}
+        `,
+			),
+		);
+	} catch (error) {
+		s.stop("Failed to create project");
+		console.error(chalk.red("Error:"), error);
+		process.exit(1);
+	}
+}
+
+main().catch(console.error);

--- a/packages/create-adk-project/src/starters.ts
+++ b/packages/create-adk-project/src/starters.ts
@@ -1,0 +1,15 @@
+export interface StarterOption {
+	value: string;
+	label: string;
+	hint: string;
+	template: string;
+}
+
+export const starters: StarterOption[] = [
+	{
+		value: "adk-agent-starter",
+		label: "🤖 ADK Agent Starter",
+		hint: "Complete agent development starter template",
+		template: "github:IQAIcom/adk-agent-starter",
+	},
+];

--- a/packages/create-adk-project/tsconfig.json
+++ b/packages/create-adk-project/tsconfig.json
@@ -1,0 +1,24 @@
+{
+  "extends": "@iqai/tsconfig/base.json",
+  "compilerOptions": {
+    "outDir": "dist",
+    "module": "ES2022",
+    "target": "ES2022",
+    "moduleResolution": "bundler",
+    "allowSyntheticDefaultImports": true,
+    "esModuleInterop": true,
+    "skipLibCheck": true,
+    "strict": true,
+    "declaration": true,
+    "types": [
+      "node"
+    ]
+  },
+  "include": [
+    "src/**/*"
+  ],
+  "exclude": [
+    "node_modules",
+    "dist"
+  ]
+}

--- a/packages/create-adk-project/tsup.config.ts
+++ b/packages/create-adk-project/tsup.config.ts
@@ -1,0 +1,18 @@
+import { defineConfig } from "tsup";
+
+export default defineConfig({
+	entry: {
+		index: "src/index.ts",
+	},
+	format: ["esm"],
+	dts: true,
+	splitting: false,
+	clean: true,
+	minify: false,
+	sourcemap: true,
+	banner: {
+		js: "#!/usr/bin/env node",
+	},
+	target: "node18",
+	platform: "node",
+});

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -243,6 +243,37 @@ importers:
         specifier: ^3.1.3
         version: 3.2.4(@types/debug@4.1.12)(@types/node@20.19.4)(jiti@2.4.2)(lightningcss@1.30.1)(tsx@4.20.3)(yaml@2.8.0)
 
+  packages/create-adk-project:
+    dependencies:
+      '@clack/prompts':
+        specifier: ^0.7.0
+        version: 0.7.0
+      chalk:
+        specifier: ^5.4.1
+        version: 5.4.1
+      dedent:
+        specifier: ^1.6.0
+        version: 1.6.0
+      giget:
+        specifier: ^1.2.3
+        version: 1.2.5
+    devDependencies:
+      '@iqai/tsconfig':
+        specifier: workspace:*
+        version: link:../tsconfig
+      '@types/node':
+        specifier: ^20.17.30
+        version: 20.19.4
+      tsup:
+        specifier: ^8.4.0
+        version: 8.5.0(jiti@2.4.2)(postcss@8.5.6)(tsx@4.20.3)(typescript@5.8.3)(yaml@2.8.0)
+      typescript:
+        specifier: ^5.3.2
+        version: 5.8.3
+      vitest:
+        specifier: ^3.1.3
+        version: 3.2.4(@types/debug@4.1.12)(@types/node@20.19.4)(jiti@2.4.2)(lightningcss@1.30.1)(tsx@4.20.3)(yaml@2.8.0)
+
   packages/tsconfig: {}
 
 packages:
@@ -405,11 +436,19 @@ packages:
   '@changesets/write@0.4.0':
     resolution: {integrity: sha512-CdTLvIOPiCNuH71pyDu3rA+Q0n65cmAbXnwWH84rKGiFumFzkmHNT8KHTMEchcxN+Kl8I54xGUhJ7l3E7X396Q==}
 
+  '@clack/core@0.3.5':
+    resolution: {integrity: sha512-5cfhQNH+1VQ2xLQlmzXMqUoiaH0lRBq9/CLW9lTyMbuKLC3+xEK01tHVvyut++mLOn5urSHmkm6I0Lg9MaJSTQ==}
+
   '@clack/core@0.5.0':
     resolution: {integrity: sha512-p3y0FIOwaYRUPRcMO7+dlmLh8PSRcrjuTndsiA0WAFbWES0mLZlrjVoBRZ9DzkPFJZG6KGkJmoEAY0ZcVWTkow==}
 
   '@clack/prompts@0.11.0':
     resolution: {integrity: sha512-pMN5FcrEw9hUkZA4f+zLlzivQSeQf5dRGJjSUbvVYDLvpKCdQx5OaknvKzgbtXOizhP+SJJJjqEbOe55uKKfAw==}
+
+  '@clack/prompts@0.7.0':
+    resolution: {integrity: sha512-0MhX9/B4iL6Re04jPrttDm+BsP8y6mS7byuv0BvXgdXhbV5PdlsHt55dvNsuBCPZ7xq1oTAOOuotR9NFbQyMSA==}
+    bundledDependencies:
+      - is-unicode-supported
 
   '@electric-sql/pglite@0.3.4':
     resolution: {integrity: sha512-h5hoL2GuxcWN8Q3+jtesIRem14iIvAZVEsTeUF6eO9RiUb6ar73QVIEW9t+Ud58iXAcAE2dFMtWqw3W2Oo4LDw==}
@@ -2307,6 +2346,10 @@ packages:
   chownr@1.1.4:
     resolution: {integrity: sha512-jJ0bqzaylmJtVnNgzTeSOs8DPavpbYgEr/b0YL8/2GO3xJEhInFmhKMUnEJQjZumK7KXGFhUy89PrsJWlakBVg==}
 
+  chownr@2.0.0:
+    resolution: {integrity: sha512-bIomtDF5KGpdogkLd9VspvFzk9KfpyyGlS8YFVZl7TGPBHL5snIOnxeshwVgPteQ9b4Eydl+pVbIyE1DcvCWgQ==}
+    engines: {node: '>=10'}
+
   chownr@3.0.0:
     resolution: {integrity: sha512-+IxzY9BZOQd/XuYPRmrvEVjF/nqj5kgT4kEq7VofrDoM1MxoRjEWkrCC3EtLi59TVawxTAn+orJwFQcrqEN1+g==}
     engines: {node: '>=18'}
@@ -2314,6 +2357,9 @@ packages:
   ci-info@3.9.0:
     resolution: {integrity: sha512-NIxF55hv4nSqQswkAeiOi1r83xy8JldOFDTWiug55KBu9Jnblncd2U6ViHmYgHf01TPZS77NJBhBMKdWj9HQMQ==}
     engines: {node: '>=8'}
+
+  citty@0.1.6:
+    resolution: {integrity: sha512-tskPPKEs8D2KPafUypv2gxwJP8h/OaJmC82QQGGDQcHvXX43xF2VDACcJVmZ0EuSxkpO9Kc4MlrA3q0+FG58AQ==}
 
   cjs-module-lexer@1.4.3:
     resolution: {integrity: sha512-9z8TZaGM1pfswYeXrUpzPrkx8UnWYdhJclsiYMm6x/w5+nN+8Tf/LnAgfLGQCm59qAOxU8WwHEq2vNwF6i4j+Q==}
@@ -2456,6 +2502,9 @@ packages:
   deep-extend@0.6.0:
     resolution: {integrity: sha512-LOHxIOaPYdHlJRtCQfDIVZtfw/ufM8+rVj649RIHzcm/vGwQRXFt6OPqIFWsm2XEMrNIEtWR64sY1LEKD2vAOA==}
     engines: {node: '>=4.0.0'}
+
+  defu@6.1.4:
+    resolution: {integrity: sha512-mEQCMmwJu317oSz8CwdIOdwf3xMif1ttiM8LTufzc3g6kR+9Pe236twL8j3IYT1F7GfRgGcW6MWxzZjLIkuHIg==}
 
   delayed-stream@1.0.0:
     resolution: {integrity: sha512-ZySD7Nf91aLB0RxL4KGrKHBXl7Eds1DAmEdcoVawXnLD7SDhpNgtuII2aAkg7a7QS41jxPSZ17p4VdGnMHk3MQ==}
@@ -2876,6 +2925,10 @@ packages:
     resolution: {integrity: sha512-yhlQgA6mnOJUKOsRUFsgJdQCvkKhcz8tlZG5HBQfReYZy46OwLcY+Zia0mtdHsOo9y/hP+CxMN0TU9QxoOtG4g==}
     engines: {node: '>=6 <7 || >=8'}
 
+  fs-minipass@2.1.0:
+    resolution: {integrity: sha512-V/JgOLFCS+R6Vcq0slCuaeWEdNC3ouDlJMNIsacH2VtALiu9mV4LPrHc5cDl8k5aw6J8jwgWWpiTo5RYhmIzvg==}
+    engines: {node: '>= 8'}
+
   fsevents@2.3.3:
     resolution: {integrity: sha512-5xoDfX+fL7faATnagmWPpbFtwh/R77WmMMqqHGS65C3vvB0YHrgF+B1YmZ3441tMj5n63k0212XNoJwzlhffQw==}
     engines: {node: ^8.16.0 || ^10.6.0 || >=11.0.0}
@@ -2984,6 +3037,10 @@ packages:
 
   get-tsconfig@4.10.1:
     resolution: {integrity: sha512-auHyJ4AgMz7vgS8Hp3N6HXSmlMdUyhSUrfBF16w153rxtLIEOE+HGqaBppczZvnHLqQJfiHotCYpNhl0lUROFQ==}
+
+  giget@1.2.5:
+    resolution: {integrity: sha512-r1ekGw/Bgpi3HLV3h1MRBIlSAdHoIMklpaQ3OQLFcRw9PwAj2rqigvIbg+dBUI51OxVI2jsEtDywDBjSiuf7Ug==}
+    hasBin: true
 
   github-from-package@0.0.0:
     resolution: {integrity: sha512-SyHy3T1v2NUXn29OsWdxmK6RwHD+vkj3v8en8AOBZ1wBQ/hCAQ5bAQTD02kW4W9tUp/3Qh6J8r9EvntiyCmOOw==}
@@ -3619,9 +3676,21 @@ packages:
   minimist@1.2.8:
     resolution: {integrity: sha512-2yyAR8qBkN3YuheJanUpWC5U3bb5osDywNB8RzDVlDwDHbocAJveqqj1u8+SVD7jkWT4yvsHCpWqqWqAxb0zCA==}
 
+  minipass@3.3.6:
+    resolution: {integrity: sha512-DxiNidxSEK+tHG6zOIklvNOwm3hvCrbUrdtzY74U6HKTJxvIDfOUL5W5P2Ghd3DTkhhKPYGqeNUIh5qcM4YBfw==}
+    engines: {node: '>=8'}
+
+  minipass@5.0.0:
+    resolution: {integrity: sha512-3FnjYuehv9k6ovOEbyOswadCDPX1piCfhV8ncmYtHOjuPwylVWsghTLo7rabjC3Rx5xD4HDx8Wm1xnMF7S5qFQ==}
+    engines: {node: '>=8'}
+
   minipass@7.1.2:
     resolution: {integrity: sha512-qOOzS1cBTWYF4BH8fVePDBOO9iptMnGUEZwNc/cMWnTV2nVLZ7VoNWEPHkYczZA0pdoA7dl6e7FL659nX9S2aw==}
     engines: {node: '>=16 || 14 >=14.17'}
+
+  minizlib@2.1.2:
+    resolution: {integrity: sha512-bAxsR8BVfj60DWXHE3u30oHzfl4G7khkSuPW+qvpd7jFRHm7dLxOjUk1EHACJ/hxLY8phGJ0YhYHZo7jil7Qdg==}
+    engines: {node: '>= 8'}
 
   minizlib@3.0.2:
     resolution: {integrity: sha512-oG62iEk+CYt5Xj2YqI5Xi9xWUeZhDI8jjQmC5oThVH5JGCTgIjr7ciJDzC7MBzYd//WvR1OTmP5Q38Q8ShQtVA==}
@@ -3629,6 +3698,11 @@ packages:
 
   mkdirp-classic@0.5.3:
     resolution: {integrity: sha512-gKLcREMhtuZRwRAfqP3RFW+TK4JqApVBtOIftVgjuABpAtpxhPGaDcfvbhNvD0B8iD1oUr/txX35NjcaY6Ns/A==}
+
+  mkdirp@1.0.4:
+    resolution: {integrity: sha512-vVqVZQyf3WLx2Shd0qJ9xuvqgAyKPLAiqITEtqW0oIUjzo3PePDd6fW9iFz30ef7Ysp/oiWqbhszeGWW2T6Gzw==}
+    engines: {node: '>=10'}
+    hasBin: true
 
   mkdirp@3.0.1:
     resolution: {integrity: sha512-+NsyUUAZDmo6YVHzL/stxSu3t9YS1iljliy3BSDrXJ/dkn1KYdmtZODGGjLcc9XLgVVpH4KshHB8XmZgMhaBXg==}
@@ -3710,6 +3784,9 @@ packages:
     engines: {node: '>=10.5.0'}
     deprecated: Use your platform's native DOMException instead
 
+  node-fetch-native@1.6.6:
+    resolution: {integrity: sha512-8Mc2HhqPdlIfedsuZoc3yioPuzp6b+L5jRCRY1QzuWZh2EGJVQrGppC6V6cF0bLdbW0+O2YpqCA25aF/1lvipQ==}
+
   node-fetch@2.7.0:
     resolution: {integrity: sha512-c4FRfUm/dbcWZ7U+1Wq0AwCyFL+3nt2bEw05wfxSz+DWpWsitgmSgYmy2dQdWyKC1694ELPqMs/YzUSNozLt8A==}
     engines: {node: 4.x || >=6.0.0}
@@ -3730,6 +3807,11 @@ packages:
   npm-to-yarn@3.0.1:
     resolution: {integrity: sha512-tt6PvKu4WyzPwWUzy/hvPFqn+uwXO0K1ZHka8az3NnrhWJDmSqI8ncWq0fkL0k/lmmi5tAC11FXwXuh0rFbt1A==}
     engines: {node: ^12.22.0 || ^14.17.0 || >=16.0.0}
+
+  nypm@0.5.4:
+    resolution: {integrity: sha512-X0SNNrZiGU8/e/zAB7sCTtdxWTMSIO73q+xuKgglm2Yvzwlo8UoC5FNySQFCvl84uPaeADkqHUZUkWy4aH4xOA==}
+    engines: {node: ^14.16.0 || >=16.10.0}
+    hasBin: true
 
   object-assign@4.1.1:
     resolution: {integrity: sha512-rJgTQnkUnH1sFw8yT6VSU3zD3sWmu6sZhIseY8VX+GRu3P6F7Fu+JNDoXfklElbLJSnc3FUQHVe4cU5hj+BcUg==}
@@ -4470,6 +4552,10 @@ packages:
     resolution: {integrity: sha512-ujeqbceABgwMZxEJnk2HDY2DlnUZ+9oEcb1KzTVfYHio0UE6dG71n60d8D2I4qNvleWrrXpmjpt7vZeF1LnMZQ==}
     engines: {node: '>=6'}
 
+  tar@6.2.1:
+    resolution: {integrity: sha512-DZ4yORTwrbTj/7MZYq2w+/ZFdI6OZ/f9SFHR+71gIVUZhOQPHzVCLpvRnPgyaMpfWxxk/4ONva3GQSyNIKRv6A==}
+    engines: {node: '>=10'}
+
   tar@7.4.3:
     resolution: {integrity: sha512-5S7Va8hKfV7W5U6g3aYxXmlPoZVAwUMy9AOKyF2fVuZa2UD3qZjg578OrLRt8PcNN1PleVaL/5/yYATNL0ICUw==}
     engines: {node: '>=18'}
@@ -4899,6 +4985,9 @@ packages:
     resolution: {integrity: sha512-0pfFzegeDWJHJIAmTLRP2DwHjdF5s7jo9tuztdQxAhINCdvS+3nGINqPd00AphqJR/0LhANUS6/+7SCb98YOfA==}
     engines: {node: '>=10'}
 
+  yallist@4.0.0:
+    resolution: {integrity: sha512-3wdGidZyq5PB084XLES5TpOSRA3wjXAlIWMhum2kRcv/41Sn2emQ0dycQW4uZXLejwKvg6EsvbdlVL+FYEct7A==}
+
   yallist@5.0.0:
     resolution: {integrity: sha512-YgvUTfwqyc7UXVMrB+SImsVYSmTS8X/tSrtdNZMImM+n7+QTriRXyXim0mBrTXNeqzVF0KWGgHPeiyViFFrNDw==}
     engines: {node: '>=18'}
@@ -5179,6 +5268,11 @@ snapshots:
       human-id: 4.1.1
       prettier: 2.8.8
 
+  '@clack/core@0.3.5':
+    dependencies:
+      picocolors: 1.1.1
+      sisteransi: 1.0.5
+
   '@clack/core@0.5.0':
     dependencies:
       picocolors: 1.1.1
@@ -5187,6 +5281,12 @@ snapshots:
   '@clack/prompts@0.11.0':
     dependencies:
       '@clack/core': 0.5.0
+      picocolors: 1.1.1
+      sisteransi: 1.0.5
+
+  '@clack/prompts@0.7.0':
+    dependencies:
+      '@clack/core': 0.3.5
       picocolors: 1.1.1
       sisteransi: 1.0.5
 
@@ -7226,9 +7326,15 @@ snapshots:
 
   chownr@1.1.4: {}
 
+  chownr@2.0.0: {}
+
   chownr@3.0.0: {}
 
   ci-info@3.9.0: {}
+
+  citty@0.1.6:
+    dependencies:
+      consola: 3.4.2
 
   cjs-module-lexer@1.4.3: {}
 
@@ -7347,6 +7453,8 @@ snapshots:
   deep-eql@5.0.2: {}
 
   deep-extend@0.6.0: {}
+
+  defu@6.1.4: {}
 
   delayed-stream@1.0.0: {}
 
@@ -7787,6 +7895,10 @@ snapshots:
       jsonfile: 4.0.0
       universalify: 0.1.2
 
+  fs-minipass@2.1.0:
+    dependencies:
+      minipass: 3.3.6
+
   fsevents@2.3.3:
     optional: true
 
@@ -7933,6 +8045,16 @@ snapshots:
   get-tsconfig@4.10.1:
     dependencies:
       resolve-pkg-maps: 1.0.0
+
+  giget@1.2.5:
+    dependencies:
+      citty: 0.1.6
+      consola: 3.4.2
+      defu: 6.1.4
+      node-fetch-native: 1.6.6
+      nypm: 0.5.4
+      pathe: 2.0.3
+      tar: 6.2.1
 
   github-from-package@0.0.0: {}
 
@@ -8839,13 +8961,26 @@ snapshots:
 
   minimist@1.2.8: {}
 
+  minipass@3.3.6:
+    dependencies:
+      yallist: 4.0.0
+
+  minipass@5.0.0: {}
+
   minipass@7.1.2: {}
+
+  minizlib@2.1.2:
+    dependencies:
+      minipass: 3.3.6
+      yallist: 4.0.0
 
   minizlib@3.0.2:
     dependencies:
       minipass: 7.1.2
 
   mkdirp-classic@0.5.3: {}
+
+  mkdirp@1.0.4: {}
 
   mkdirp@3.0.1: {}
 
@@ -8930,6 +9065,8 @@ snapshots:
 
   node-domexception@1.0.0: {}
 
+  node-fetch-native@1.6.6: {}
+
   node-fetch@2.7.0:
     dependencies:
       whatwg-url: 5.0.0
@@ -8944,6 +9081,15 @@ snapshots:
       unicorn-magic: 0.3.0
 
   npm-to-yarn@3.0.1: {}
+
+  nypm@0.5.4:
+    dependencies:
+      citty: 0.1.6
+      consola: 3.4.2
+      pathe: 2.0.3
+      pkg-types: 1.3.1
+      tinyexec: 0.3.2
+      ufo: 1.6.1
 
   object-assign@4.1.1: {}
 
@@ -9784,6 +9930,15 @@ snapshots:
       inherits: 2.0.4
       readable-stream: 3.6.2
 
+  tar@6.2.1:
+    dependencies:
+      chownr: 2.0.0
+      fs-minipass: 2.1.0
+      minipass: 5.0.0
+      minizlib: 2.1.2
+      mkdirp: 1.0.4
+      yallist: 4.0.0
+
   tar@7.4.3:
     dependencies:
       '@isaacs/fs-minipass': 4.0.1
@@ -10194,6 +10349,8 @@ snapshots:
   xtend@4.0.2: {}
 
   y18n@5.0.8: {}
+
+  yallist@4.0.0: {}
 
   yallist@5.0.0: {}
 


### PR DESCRIPTION
## Changes
Introduce a CLI tool for scaffolding ADK TypeScript projects with various framework templates. The tool features interactive prompts, automatic dependency installation, and integrates with GitHub for template cloning. Documentation and usage instructions are included in the README.

## Screenshots
<img width="1604" height="800" alt="CleanShot 2025-07-15 at 21 25 38@2x" src="https://github.com/user-attachments/assets/726e6fa5-c025-4bbe-a22f-9cda5ace1a51" />
