### PR TITLE
Fix TypeScript Path Resolution in Agent Loader

### DIFF
--- a/.changeset/funny-chairs-invent.md
+++ b/.changeset/funny-chairs-invent.md
@@ -1,0 +1,5 @@
+---
+"@iqai/adk-cli": patch
+---
+
+Fix TypeScript Path Resolution in Agent Loader


### PR DESCRIPTION
*Closes https://github.com/IQAIcom/adk-ts/issues/249 when this PR merged*

## Changes
- Added enhanced esbuild plugin to resolve TypeScript path mappings from tsconfig.json, fixing Cannot find module errors for relative imports and path aliases in agent projects.