### PR TITLE
feat: remove redundant --local option from web command

### DIFF
--- a/apps/adk-web/components/ui/states.tsx
+++ b/apps/adk-web/components/ui/states.tsx
@@ -70,7 +70,7 @@ export function ErrorState({
 
 				{/* Quick instructions to run ADK Web locally */}
 				<div className="mt-6 text-left max-w-xl mx-auto">
-					<p className="text-sm font-medium mb-2">How to run ADK Web locally</p>
+					<p className="text-sm font-medium mb-2">How to run ADK Web</p>
 					<div className="rounded-md border p-4 bg-muted/30">
 						<p className="text-sm mb-2">1. Install the CLI:</p>
 						<pre className="bg-background p-2 rounded text-xs overflow-auto">
@@ -86,8 +86,7 @@ export function ErrorState({
 								Use specific API server port: <code>adk web --port 8080</code>
 							</li>
 							<li>
-								Custom web app port:{" "}
-								<code>adk web --local --web-port 3000</code>
+								Scan custom directory: <code>adk web --dir ./my-agents</code>
 							</li>
 						</ul>
 					</div>

--- a/apps/docs/content/docs/cli/commands.mdx
+++ b/apps/docs/content/docs/cli/commands.mdx
@@ -53,8 +53,6 @@ adk web
 adk web --port 8080
 # Scan a custom directory
 adk web --dir ./my-agents
-# Run local development version
-adk web --local --web-port 3000
 # Custom web application URL
 adk web --web-url https://custom-web-app.com
 ```

--- a/apps/docs/content/docs/cli/index.mdx
+++ b/apps/docs/content/docs/cli/index.mdx
@@ -57,7 +57,7 @@ npm install
 adk run
 
 # 4. Launch the web interface (in another terminal)
-adk web --local
+adk web
 ```
 
 ## Additional Usage Examples

--- a/packages/adk-cli/README.md
+++ b/packages/adk-cli/README.md
@@ -126,9 +126,6 @@ adk web --port 8080
 # Scan custom directory for agents
 adk web --dir ./my-agents
 
-# Run local development version
-adk web --local --web-port 3000
-
 # Custom web application URL
 adk web --web-url https://custom-web-app.com
 ```
@@ -182,7 +179,7 @@ npm install
 adk run
 
 # 4. In another terminal, start web interface
-adk web --local
+adk web
 ```
 
 ### Multi-Agent Development

--- a/packages/adk-cli/src/cli/web.command.ts
+++ b/packages/adk-cli/src/cli/web.command.ts
@@ -6,8 +6,6 @@ interface WebCommandOptions {
 	port?: number;
 	dir?: string;
 	host?: string;
-	webPort?: number;
-	local?: boolean;
 	webUrl?: string;
 }
 
@@ -21,9 +19,7 @@ export class WebCommand extends CommandRunner {
 		options?: WebCommandOptions,
 	): Promise<void> {
 		const apiPort = options?.port ?? 8042;
-		const webPort = options?.webPort ?? 3000;
 		const host = options?.host ?? "localhost";
-		const useLocal = options?.local ?? false;
 		const webUrl = options?.webUrl ?? "https://adk-web.iqai.com";
 
 		console.log(chalk.blue("🌐 Starting ADK Web Interface..."));
@@ -36,22 +32,8 @@ export class WebCommand extends CommandRunner {
 			quiet: true,
 		});
 
-		let webAppUrl: string;
-		if (useLocal) {
-			// Local development: assume web app is already running on webPort
-			if (apiPort === 8042) {
-				webAppUrl = `http://${host}:${webPort}`;
-			} else {
-				webAppUrl = `http://${host}:${webPort}?port=${apiPort}`;
-			}
-		} else {
-			// Production hosted UI
-			if (apiPort === 8042) {
-				webAppUrl = webUrl;
-			} else {
-				webAppUrl = `${webUrl}?port=${apiPort}`;
-			}
-		}
+		// Build the web app URL - add port param if not using default
+		const webAppUrl = apiPort === 8042 ? webUrl : `${webUrl}?port=${apiPort}`;
 
 		console.log(chalk.cyan(`🔗 Open this URL in your browser: ${webAppUrl}`));
 		console.log(chalk.gray(`   API Server: http://${host}:${apiPort}`));
@@ -79,14 +61,6 @@ export class WebCommand extends CommandRunner {
 	}
 
 	@Option({
-		flags: "--web-port <port>",
-		description: "Port for web app (when using --local)",
-	})
-	parseWebPort(val: string): number {
-		return Number(val);
-	}
-
-	@Option({
 		flags: "-h, --host <host>",
 		description: "Host for servers",
 	})
@@ -103,16 +77,8 @@ export class WebCommand extends CommandRunner {
 	}
 
 	@Option({
-		flags: "--local",
-		description: "Run local web app instead of opening production URL",
-	})
-	parseLocal(): boolean {
-		return true;
-	}
-
-	@Option({
 		flags: "--web-url <url>",
-		description: "URL of the web application (used when not --local)",
+		description: "URL of the web application",
 	})
 	parseWebUrl(val: string): string {
 		return val;


### PR DESCRIPTION
# Pull Request

## Description
Remove redundant `--local` option from the `adk web` command. The `--local` flag was duplicating functionality already provided by `adk serve`, and the web client automatically connects to the specified API server port, making the local development mode unnecessary.

This change simplifies the command interface by:
- Removing `--local` flag and `parseLocal()` method
- Removing `webPort` option and related logic  
- Simplifying URL construction to only handle production hosted UI
- Updating documentation and error messages to reflect changes
- Cleaning up command interface for better UX

## Related Issue
<!-- Link to the issue that this PR resolves, if applicable -->
<!-- Use GitHub keywords like "closes #issue_number" or "fixes #issue_number" -->

## Type of Change
<!-- Check the boxes that apply -->
- [ ] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [x] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [x] Documentation update
- [ ] Performance improvement
- [x] Code refactoring (no functional changes)
- [ ] Tests
- [ ] Other (please describe):

## How Has This Been Tested?
- Verified `adk web` works with default settings
- Verified `adk web --port 8080` correctly passes port parameter to web UI
- Confirmed web client automatically connects to API server on specified ports
- Tested documentation updates reflect new simplified behavior

## Checklist
<!-- Check the boxes that apply -->
- [x] My code follows the code style of this project
- [x] I have updated the documentation accordingly
- [ ] I have added tests to cover my changes
- [ ] All new and existing tests passed
- [x] My changes generate no new warnings
- [x] I have checked for potential breaking changes and addressed them

## Additional Notes
**BREAKING CHANGE:** `--local` and `--web-port` flags removed from `adk web` command

**Migration Path:**
- **Before:** `adk web --local --web-port 3000`  
- **After:** Use `adk serve` for local development instead

This creates clearer separation of concerns:
- `adk web` → Production web interface  
- `adk serve` → Local development server