### PR TITLE
Fix: --dir flag by implementing proper project root discovery

### DIFF
--- a/packages/adk-cli/src/common/types.ts
+++ b/packages/adk-cli/src/common/types.ts
@@ -4,6 +4,7 @@ export interface Agent {
 	relativePath: string;
 	name: string;
 	absolutePath: string;
+	projectRoot: string;
 	instance?: BaseAgent; // Store the loaded agent instance
 }
 

--- a/packages/adk-cli/src/http/providers/agent-manager.service.ts
+++ b/packages/adk-cli/src/http/providers/agent-manager.service.ts
@@ -112,9 +112,10 @@ export class AgentManager {
 
 		const agentFileUrl = pathToFileURL(agentFilePath).href;
 
-		// Use dynamic import to load the agent (TS path uses esbuild wrapper returning { agent })
+		// Use dynamic import to load the agent
+		// For TS files, pass the project root to avoid redundant project root discovery
 		const agentModule: Record<string, unknown> = agentFilePath.endsWith(".ts")
-			? await this.loader.importTypeScriptFile(agentFilePath)
+			? await this.loader.importTypeScriptFile(agentFilePath, agent.projectRoot)
 			: ((await import(agentFileUrl)) as Record<string, unknown>);
 
 		const exportedAgent = await this.loader.resolveAgentExport(agentModule);


### PR DESCRIPTION

## Fix: --dir flag by implementing proper project root discovery

Enhances project root discovery and path resolution for TypeScript agents to fix errors when using subdirectories with the `--dir` flag.

Key improvements:

* Traverse up from the scan directory to find `tsconfig.json` or `package.json` as the project root.
* Calculate agent paths relative to the project root instead of the scan directory.
* Pass discovered project root to `AgentLoader` to prevent redundant discovery.
* Fix `esbuild` `absWorkingDir` to use the actual project root.
* Add `projectRoot` field to the `Agent` type for consistent configuration resolution.
* Improved error handling and logging for easier debugging.

Fixes the `esbuild "working directory is not an absolute path"` error for agents located in subdirectories.


## Type of Change

* [x] Bug fix (non-breaking change that fixes an issue)
* [x] Code refactoring (improves structure/organization without changing functionality)

## Problem

When using the `--dir` flag to specify an agent directory, TypeScript agents fail to load with errors like:

* `Failed to parse tsconfig.json: Expected property name or '}' in JSON at position 4`
* `Build failed with 1 error: The working directory "." is not an absolute path`

This happens because the scan directory is incorrectly treated as the project root, but the actual project root (with `tsconfig.json`, `package.json`, etc.) is often higher in the directory hierarchy.

## Root Cause

1. **AgentScanner** used the `--dir` path directly for relative calculations.
2. **AgentLoader** received inconsistent paths due to the scanner’s behavior.
3. **esbuild** used a relative working directory instead of an absolute path.
4. Agent keys differed when scanning with `--dir` versus default scanning.

## Solution

### 1. Enhanced Project Root Discovery

* Added `findProjectRoot()` to traverse up from scan directory.
* Looks for `package.json`, `tsconfig.json`, `.env`, or `.git` to detect project root.
* Ensures consistent root discovery for scanner and loader.

### 2. Consistent Agent Path Calculation

* Paths calculated relative to project root.
* Normalizes path separators for cross-platform consistency.
* Agent keys now remain consistent regardless of scanning method.

### 3. Improved AgentLoader Integration

* Optional `projectRoot` parameter added to `importTypeScriptFile()`.
* Scanner passes project root to avoid repeated traversal.
* `absWorkingDir` in esbuild set to the project root.

### 4. Type Safety Improvements

* Added `projectRoot` to `Agent` interface.
* Store project root in each agent to ensure proper configuration resolution.

## How Has This Been Tested?

* ✅ Works without `--dir` flag (default behavior preserved)
* ✅ Works with `--dir` pointing to subdirectories
* ✅ Correctly finds and uses `tsconfig.json` from project root
* ✅ Resolves TypeScript path mappings correctly
* ✅ Handles deeply nested agent directories
* ✅ Cross-platform path handling (Windows/Unix)

## Checklist

* [x] My code follows the code style of this project
* [x] I have updated the documentation accordingly
* [x] I have added tests to cover my changes
* [x] All new and existing tests passed
* [x] My changes generate no new warnings
* [x] Checked for potential breaking changes and addressed them


## Additional Notes

This change fixes the `esbuild` error when agents are in subdirectories and standardizes path handling across the project, ensuring consistent and reliable TypeScript agent loading.

