### PR TITLE
fix: update Discord invite links and Google API key references in templates

### DIFF
--- a/.github/ISSUE_TEMPLATE/config.yml
+++ b/.github/ISSUE_TEMPLATE/config.yml
@@ -2,7 +2,7 @@ blank_issues_enabled: false
 contact_links:
   - name: ADK-TS Documentation
     url: https://adk.iqai.com/docs
-    about: Check our documentation for guides and API references
+    about: Check the official ADK-TS documentation for framework guides and API references
   - name: Discord Community
-    url: https://discord.com/invite/x9EWvTcPXt
-    about: Join our community for real-time discussions and support
+    url: https://discord.gg/w2Uk6ACK4D
+    about: Join our community for discussions and support with ADK-TS

--- a/README.md
+++ b/README.md
@@ -113,7 +113,7 @@ All contributions are welcome! Please check out our [Contributing Guide](CONTRIB
 
 Join our community to discuss ideas, ask questions, and share your projects:
 
-- [Discord Community](https://discord.com/invite/x9EWvTcPXt)
+- [Discord Community](https://discord.gg/w2Uk6ACK4D)
 - [GitHub Discussions](https://github.com/IQAIcom/adk-ts/discussions)
 
 ## 📜 License

--- a/apps/docs/content/docs/framework/get-started/index.mdx
+++ b/apps/docs/content/docs/framework/get-started/index.mdx
@@ -152,7 +152,7 @@ Join our community for help, discussions, and updates:
   <Card
     title="💼 Discord"
     description="Join our Discord server for real-time collaboration and support"
-    href="https://discord.com/invite/x9EWvTcPXt"
+    href="https://discord.gg/w2Uk6ACK4D"
     target="_blank"
     rel="noopener noreferrer"
   />

--- a/apps/starter-templates/discord-bot/.env.example
+++ b/apps/starter-templates/discord-bot/.env.example
@@ -3,7 +3,7 @@ DISCORD_TOKEN= # Get this from Discord Developer Portal
 
 # AI Model Configuration
 LLM_MODEL="gemini-2.5-flash" # Default LLM model
-GOOGLE_API_KEY= # Get it from https://aistudio.google.com/apikey
+GOOGLE_API_KEY= # Get it from https://aistudio.google.com/api-keys
 
 # Debug Configuration
 ADK_DEBUG="false" # enable this for framework logs

--- a/apps/starter-templates/hono-server/.env.example
+++ b/apps/starter-templates/hono-server/.env.example
@@ -1,4 +1,4 @@
 ADK_DEBUG="false" # enable this for framework logs
-GOOGLE_API_KEY= # get it from https://aistudio.google.com/apikey
+GOOGLE_API_KEY= # get it from https://aistudio.google.com/api-keys
 PORT="3000" # Port for the Hono server
 LLM_MODEL="gemini-2.5-flash" # Default LLM model

--- a/apps/starter-templates/shade-agent/.env.development.local.example
+++ b/apps/starter-templates/shade-agent/.env.development.local.example
@@ -5,7 +5,7 @@
 ADK_DEBUG=false
 
 # AI MODEL CONFIGURATION
-# Required: Get your free API key from https://aistudio.google.com/apikey
+# Required: Get your free API key from https://aistudio.google.com/api-keys
 # This is used by the AI agents to analyze sentiment and process data
 GOOGLE_API_KEY=
 

--- a/apps/starter-templates/shade-agent/README.md
+++ b/apps/starter-templates/shade-agent/README.md
@@ -66,7 +66,7 @@ pnpm install
 
 #### 🔑 Google AI API Key (Required)
 
-1. Visit [Google AI Studio](https://aistudio.google.com/apikey)
+1. Visit [Google AI Studio](https://aistudio.google.com/api-keys)
 2. Sign in with your Google account
 3. Click "Create API Key"
 4. Copy the generated key
@@ -299,7 +299,7 @@ src/
 
 ### "Google API key invalid"
 
-- Ensure the API key is from [Google AI Studio](https://aistudio.google.com/apikey)
+- Ensure the API key is from [Google AI Studio](https://aistudio.google.com/api-keys)
 - Make sure there are no extra spaces in your `.env` file
 
 ## 📚 Learn More

--- a/apps/starter-templates/simple-agent/.env.example
+++ b/apps/starter-templates/simple-agent/.env.example
@@ -1,2 +1,2 @@
 ADK_DEBUG="false" # enable this for framework logs
-GOOGLE_API_KEY= # get it from https://aistudio.google.com/apikey
+GOOGLE_API_KEY= # get it from https://aistudio.google.com/api-keys

--- a/apps/starter-templates/telegram-bot/.env.example
+++ b/apps/starter-templates/telegram-bot/.env.example
@@ -3,7 +3,7 @@ TELEGRAM_BOT_TOKEN= # Get this from @BotFather on Telegram
 
 # AI Model Configuration
 LLM_MODEL="gemini-2.5-flash" # Default LLM model
-GOOGLE_API_KEY= # Get it from https://aistudio.google.com/apikey
+GOOGLE_API_KEY= # Get it from https://aistudio.google.com/api-keys
 
 # Debug Configuration
 ADK_DEBUG="false" # enable this for framework logs

--- a/package.json
+++ b/package.json
@@ -24,7 +24,7 @@
 		"tsx": "^4.19.4",
 		"turbo": "^2.3.3"
 	},
-	"packageManager": "pnpm@9.0.0",
+	"packageManager": "pnpm@10.17.1",
 	"engines": {
 		"node": ">=22.0"
 	},

--- a/package.json
+++ b/package.json
@@ -24,7 +24,7 @@
 		"tsx": "^4.19.4",
 		"turbo": "^2.3.3"
 	},
-	"packageManager": "pnpm@10.17.1",
+	"packageManager": "pnpm@9.0.0",
 	"engines": {
 		"node": ">=22.0"
 	},


### PR DESCRIPTION
# Pull Request

## Description
<!-- Provide a concise description of the changes made in this PR -->
- The google api keys page has changed. Due to Google AI Studio's new ui.
- The Discord server link is now a public invite link to the welcome channel. The previous one was meant for a private invite.

## Related Issue
<!-- Link to the issue that this PR resolves, if applicable -->
<!-- Use GitHub keywords like "closes #issue_number" or "fixes #issue_number" -->

## Type of Change
<!-- Check the boxes that apply -->
- [ ] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [x] Documentation update
- [ ] Performance improvement
- [ ] Code refactoring (no functional changes)
- [ ] Tests
- [ ] Other (please describe):

## How Has This Been Tested?
<!-- Please describe the tests that you ran to verify your changes -->
<!-- Include relevant details for your test configuration -->

## Checklist
<!-- Check the boxes that apply -->
- [x] My code follows the code style of this project
- [x] I have updated the documentation accordingly
- [ ] I have added tests to cover my changes
- [ ] All new and existing tests passed
- [ ] My changes generate no new warnings
- [x] I have checked for potential breaking changes and addressed them

## Screenshots (if applicable)
<!-- Add screenshots to help explain your changes -->

## Additional Notes
<!-- Add any other context about the PR here -->
