### PR TITLE
Adds version compatibility check for ADK web

### DIFF
--- a/apps/adk-web/Api.ts
+++ b/apps/adk-web/Api.ts
@@ -47,7 +47,7 @@ export interface MessageItemDto {
   type: "user" | "assistant";
   /** @example "Hello" */
   content: string;
-  /** @example "2025-10-06T08:53:52.205Z" */
+  /** @example "2025-10-07T09:08:35.093Z" */
   timestamp: string;
 }
 
@@ -67,9 +67,9 @@ export interface SessionResponseDto {
   state: object;
   /** @example 3 */
   eventCount: number;
-  /** @example 1759740832206 */
+  /** @example 1759828115094 */
   lastUpdateTime: number;
-  /** @example 1759740832206 */
+  /** @example 1759828115094 */
   createdAt: number;
 }
 
@@ -85,7 +85,7 @@ export interface SuccessResponseDto {
 export interface EventItemDto {
   id: string;
   author: string;
-  /** @example 1759740832207 */
+  /** @example 1759828115094 */
   timestamp: number;
   /** Raw event content */
   content: object;
@@ -104,7 +104,7 @@ export interface EventsResponseDto {
 }
 
 export interface StateMetadataDto {
-  /** @example 1759740832207 */
+  /** @example 1759828115094 */
   lastUpdated: number;
   /** @example 0 */
   changeCount: number;
@@ -124,6 +124,8 @@ export interface StateResponseDto {
 export interface HealthResponseDto {
   /** @example "ok" */
   status: string;
+  /** @example "0.3.11" */
+  version?: string;
 }
 
 export type QueryParamsType = Record<string | number, any>;

--- a/apps/adk-web/app/layout.tsx
+++ b/apps/adk-web/app/layout.tsx
@@ -4,6 +4,7 @@ import "./globals.css";
 import { QueryProvider } from "@/components/query-provider";
 import { ThemeProvider } from "@/components/theme-provider";
 import { Toaster } from "@/components/ui/sonner";
+import { VersionCheck } from "@/components/version-check";
 
 const geistSans = Geist({
 	variable: "--font-geist-sans",
@@ -82,6 +83,7 @@ export default function RootLayout({
 					enableSystem
 					disableTransitionOnChange
 				>
+					<VersionCheck />
 					<QueryProvider>{children}</QueryProvider>
 				</ThemeProvider>
 				<Toaster />

--- a/apps/adk-web/components/version-check.tsx
+++ b/apps/adk-web/components/version-check.tsx
@@ -1,0 +1,62 @@
+"use client";
+
+import { useEffect } from "react";
+import { toast } from "sonner";
+import { satisfies as semverSatisfies, coerce as semverCoerce } from "semver";
+import { useApiUrl } from "@/hooks/use-api-url";
+import pkg from "../package.json";
+
+// Contract: call GET /health to read { status: "ok", version?: string }
+type HealthResponse = { status: string; version?: string };
+
+// Define the server version range this web UI is compatible with.
+// By default, keep it compatible with same minor of @iqai/adk-cli.
+// You can override via NEXT_PUBLIC_ADK_SERVER_RANGE if needed for hotfixes.
+const RANGE_FROM_PKG = (pkg as any)?.adk?.serverRange as string | undefined;
+const DEFAULT_SERVER_RANGE =
+	process.env.NEXT_PUBLIC_ADK_SERVER_RANGE ?? RANGE_FROM_PKG ?? "^0.3.11";
+
+export function VersionCheck() {
+	const apiBase = useApiUrl();
+
+	useEffect(() => {
+		let cancelled = false;
+
+		async function run() {
+			try {
+				const res = await fetch(`${apiBase}/health`, { cache: "no-store" });
+				if (!res.ok) return;
+				const body = (await res.json()) as HealthResponse;
+				const serverVersion = body.version;
+				if (!serverVersion) {
+					// Unknown server version: warn but don’t block
+					toast.message("ADK server version not reported", {
+						description:
+							"Your local ADK server did not report a version. Some features may not work as expected.",
+					});
+					return;
+				}
+
+				const coerced = semverCoerce(serverVersion)?.version;
+				if (!coerced) return;
+				const ok = semverSatisfies(coerced, DEFAULT_SERVER_RANGE, {
+					includePrerelease: true,
+				});
+				if (!ok && !cancelled) {
+					toast.warning("ADK server may be outdated", {
+						description: `Web UI expects server ${DEFAULT_SERVER_RANGE}, but found ${serverVersion}. Please update @iqai/adk-cli.`,
+					});
+				}
+			} catch {
+				// ignore – server may be offline; other UI already handles connectivity
+			}
+		}
+
+		run();
+		return () => {
+			cancelled = true;
+		};
+	}, [apiBase]);
+
+	return null;
+}

--- a/apps/adk-web/components/version-check.tsx
+++ b/apps/adk-web/components/version-check.tsx
@@ -1,13 +1,12 @@
 "use client";
 
-import { useEffect } from "react";
+import { useQuery } from "@tanstack/react-query";
+import { useEffect, useRef } from "react";
 import { coerce as semverCoerce, satisfies as semverSatisfies } from "semver";
 import { toast } from "sonner";
 import { useApiUrl } from "@/hooks/use-api-url";
+import { Api, HealthResponseDto } from "../Api";
 import pkg from "../package.json";
-
-// Contract: call GET /health to read { status: "ok", version?: string }
-type HealthResponse = { status: string; version?: string };
 
 // Define the server version range this web UI is compatible with.
 // By default, keep it compatible with same minor of @iqai/adk-cli.
@@ -19,44 +18,52 @@ const DEFAULT_SERVER_RANGE =
 export function VersionCheck() {
 	const apiBase = useApiUrl();
 
+	// Fetch health with React Query
+	const { data } = useQuery<HealthResponseDto, Error>({
+		queryKey: ["health", apiBase],
+		queryFn: async () => {
+			const api = new Api({ baseUrl: apiBase });
+			const resp = await api.health.healthControllerHealth();
+			return resp.data;
+		},
+		staleTime: 5 * 60 * 1000,
+		gcTime: 10 * 60 * 1000,
+		retry: 0,
+		enabled: !!apiBase,
+		refetchOnWindowFocus: false,
+	});
+
+	// Deduplicate notifications per apiBase
+	const notifiedRef = useRef<string | null>(null);
+
 	useEffect(() => {
-		let cancelled = false;
+		if (!data) return;
+		const { version: serverVersion } = data;
 
-		async function run() {
-			try {
-				const res = await fetch(`${apiBase}/health`, { cache: "no-store" });
-				if (!res.ok) return;
-				const body = (await res.json()) as HealthResponse;
-				const serverVersion = body.version;
-				if (!serverVersion) {
-					// Unknown server version: warn but don’t block
-					toast.message("ADK server version not reported", {
-						description:
-							"Your local ADK server did not report a version. Some features may not work as expected.",
-					});
-					return;
-				}
+		// Only notify once per base URL version snapshot
+		const key = `${apiBase}:${serverVersion ?? "none"}`;
+		if (notifiedRef.current === key) return;
+		notifiedRef.current = key;
 
-				const coerced = semverCoerce(serverVersion)?.version;
-				if (!coerced) return;
-				const ok = semverSatisfies(coerced, DEFAULT_SERVER_RANGE, {
-					includePrerelease: true,
-				});
-				if (!ok && !cancelled) {
-					toast.warning("ADK server may be outdated", {
-						description: `Web UI expects server ${DEFAULT_SERVER_RANGE}, but found ${serverVersion}. Please update @iqai/adk-cli.`,
-					});
-				}
-			} catch {
-				// ignore – server may be offline; other UI already handles connectivity
-			}
+		if (!serverVersion) {
+			toast.message("ADK server version not reported", {
+				description:
+					"Your local ADK server did not report a version. Some features may not work as expected.",
+			});
+			return;
 		}
 
-		run();
-		return () => {
-			cancelled = true;
-		};
-	}, [apiBase]);
+		const coerced = semverCoerce(serverVersion)?.version;
+		if (!coerced) return;
+		const ok = semverSatisfies(coerced, DEFAULT_SERVER_RANGE, {
+			includePrerelease: true,
+		});
+		if (!ok) {
+			toast.warning("ADK server may be outdated", {
+				description: `Web UI expects server ${DEFAULT_SERVER_RANGE}, but found ${serverVersion}. Please update @iqai/adk-cli.`,
+			});
+		}
+	}, [data, apiBase]);
 
 	return null;
 }

--- a/apps/adk-web/components/version-check.tsx
+++ b/apps/adk-web/components/version-check.tsx
@@ -1,8 +1,8 @@
 "use client";
 
 import { useEffect } from "react";
+import { coerce as semverCoerce, satisfies as semverSatisfies } from "semver";
 import { toast } from "sonner";
-import { satisfies as semverSatisfies, coerce as semverCoerce } from "semver";
 import { useApiUrl } from "@/hooks/use-api-url";
 import pkg from "../package.json";
 

--- a/apps/adk-web/openapi.json
+++ b/apps/adk-web/openapi.json
@@ -616,7 +616,7 @@
 					},
 					"timestamp": {
 						"type": "string",
-						"example": "2025-10-06T08:53:52.205Z"
+						"example": "2025-10-07T09:08:35.093Z"
 					}
 				},
 				"required": ["id", "type", "content", "timestamp"]
@@ -664,11 +664,11 @@
 					},
 					"lastUpdateTime": {
 						"type": "number",
-						"example": 1759740832206
+						"example": 1759828115094
 					},
 					"createdAt": {
 						"type": "number",
-						"example": 1759740832206
+						"example": 1759828115094
 					}
 				},
 				"required": [
@@ -714,7 +714,7 @@
 					},
 					"timestamp": {
 						"type": "number",
-						"example": 1759740832207
+						"example": 1759828115094
 					},
 					"content": {
 						"type": "object",
@@ -777,7 +777,7 @@
 				"properties": {
 					"lastUpdated": {
 						"type": "number",
-						"example": 1759740832207
+						"example": 1759828115094
 					},
 					"changeCount": {
 						"type": "number",
@@ -818,6 +818,10 @@
 					"status": {
 						"type": "string",
 						"example": "ok"
+					},
+					"version": {
+						"type": "string",
+						"example": "0.3.11"
 					}
 				},
 				"required": ["status"]

--- a/apps/adk-web/package.json
+++ b/apps/adk-web/package.json
@@ -48,8 +48,8 @@
 		"rehype-katex": "^7.0.1",
 		"remark-gfm": "^4.0.1",
 		"remark-math": "^6.0.0",
+		"semver": "^7.7.2",
 		"sonner": "^2.0.7",
-		"semver": "^7.6.3",
 		"streamdown": "^1.2.0",
 		"tailwind-merge": "^3.3.1",
 		"use-stick-to-bottom": "^1.1.1",
@@ -61,6 +61,7 @@
 		"@types/react": "^19.1.12",
 		"@types/react-dom": "^19.1.9",
 		"@types/react-syntax-highlighter": "^15.5.13",
+		"@types/semver": "^7.7.1",
 		"tailwindcss": "^4.1.13",
 		"tw-animate-css": "^1.3.8",
 		"typescript": "^5.9.2"

--- a/apps/adk-web/package.json
+++ b/apps/adk-web/package.json
@@ -2,6 +2,9 @@
 	"name": "adk-web",
 	"version": "0.1.1",
 	"private": true,
+	"adk": {
+		"serverRange": "^0.3.11"
+	},
 	"scripts": {
 		"dev": "next dev",
 		"build": "next build",
@@ -46,6 +49,7 @@
 		"remark-gfm": "^4.0.1",
 		"remark-math": "^6.0.0",
 		"sonner": "^2.0.7",
+		"semver": "^7.6.3",
 		"streamdown": "^1.2.0",
 		"tailwind-merge": "^3.3.1",
 		"use-stick-to-bottom": "^1.1.1",

--- a/packages/adk-cli/src/http/dto/api.dto.ts
+++ b/packages/adk-cli/src/http/dto/api.dto.ts
@@ -97,6 +97,7 @@ export class StateResponseDto {
 // Health
 export class HealthResponseDto {
 	@ApiProperty({ example: "ok" }) status!: string;
+	@ApiProperty({ example: "0.3.11", required: false }) version?: string;
 }
 
 // Graph

--- a/packages/adk-cli/src/http/health/health.controller.ts
+++ b/packages/adk-cli/src/http/health/health.controller.ts
@@ -13,6 +13,16 @@ export class HealthController {
 	})
 	@ApiOkResponse({ type: HealthResponseDto })
 	health() {
-		return { status: "ok" };
+		// Read version from this package.json at runtime; fallback to env or unknown
+		let version: string | undefined;
+		try {
+			// eslint-disable-next-line @typescript-eslint/no-var-requires
+			const pkg = require("../../package.json");
+			if (pkg && typeof pkg.version === "string") {
+				version = pkg.version;
+			}
+		} catch {}
+		version = version ?? process.env.ADK_CLI_VERSION ?? undefined;
+		return { status: "ok", version };
 	}
 }

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -140,6 +140,9 @@ importers:
       remark-math:
         specifier: ^6.0.0
         version: 6.0.0
+      semver:
+        specifier: ^7.7.2
+        version: 7.7.2
       sonner:
         specifier: ^2.0.7
         version: 2.0.7(react-dom@19.1.1(react@19.1.1))(react@19.1.1)
@@ -171,6 +174,9 @@ importers:
       '@types/react-syntax-highlighter':
         specifier: ^15.5.13
         version: 15.5.13
+      '@types/semver':
+        specifier: ^7.7.1
+        version: 7.7.1
       tailwindcss:
         specifier: ^4.1.13
         version: 4.1.13
@@ -394,7 +400,7 @@ importers:
         version: 17.2.2
       drizzle-orm:
         specifier: ^0.44.5
-        version: 0.44.5(@electric-sql/pglite@0.3.8)(@opentelemetry/api@1.9.0)(@types/better-sqlite3@7.6.13)(@types/pg@8.15.5)(better-sqlite3@11.10.0)(kysely@0.28.5)(mysql2@3.14.5)(pg@8.16.3)
+        version: 0.44.5(@electric-sql/pglite@0.3.8)(@opentelemetry/api@1.9.0)(@types/better-sqlite3@7.6.13)(@types/pg@8.15.5)(better-sqlite3@12.4.1)(kysely@0.28.5)(mysql2@3.14.5)(pg@8.16.3)
       jsonrepair:
         specifier: ^3.13.0
         version: 3.13.0
@@ -431,7 +437,7 @@ importers:
         version: 24.3.1
       better-sqlite3:
         specifier: ^12.2.0
-        version: 11.10.0
+        version: 12.4.1
       mysql2:
         specifier: ^3.14.5
         version: 3.14.5
@@ -2803,6 +2809,9 @@ packages:
   '@types/request@2.48.13':
     resolution: {integrity: sha512-FGJ6udDNUCjd19pp0Q3iTiDkwhYup7J8hpMW9c4k53NrccQFFWKRho6hvtPPEhnXWKvukfwAlB6DbDz4yhH5Gg==}
 
+  '@types/semver@7.7.1':
+    resolution: {integrity: sha512-FmgJfu+MOcQ370SD0ev7EI8TlCAfKYU+B4m5T3yXc1CiRN94g/SZPtsCkk506aUDtlMnFZvasDwHHUcZUEaYuA==}
+
   '@types/ssh2@1.15.5':
     resolution: {integrity: sha512-N1ASjp/nXH3ovBHddRJpli4ozpk6UdDYIX4RJWFa9L1YKnzdhTlVmiGHm4DZnj/jLbqZpes4aeR30EFGQtvhQQ==}
 
@@ -3022,8 +3031,9 @@ packages:
     resolution: {integrity: sha512-pbnl5XzGBdrFU/wT4jqmJVPn2B6UHPBOhzMQkY/SPUPB6QtUXtmBHBIwCbXJol93mOpGMnQyP/+BB19q04xj7g==}
     engines: {node: '>=4'}
 
-  better-sqlite3@11.10.0:
-    resolution: {integrity: sha512-EwhOpyXiOEL/lKzHz9AW1msWFNzGc/z+LzeB3/jnFJpxu+th2yqvzsSWas1v9jgs9+xiXJcD5A8CJxAG2TaghQ==}
+  better-sqlite3@12.4.1:
+    resolution: {integrity: sha512-3yVdyZhklTiNrtg+4WqHpJpFDd+WHTg2oM7UcR80GqL05AOV0xEJzc6qNvFYoEtE+hRp1n9MpN6/+4yhlGkDXQ==}
+    engines: {node: 20.x || 22.x || 23.x || 24.x}
 
   bignumber.js@9.3.1:
     resolution: {integrity: sha512-Ko0uX15oIUS7wJ3Rb30Fs6SkVbLmPBAKdlm7q9+ak9bbIeFf0MwuBsQV6z7+X768/cHsfg+WlysDWJcmthjsjQ==}
@@ -9193,6 +9203,8 @@ snapshots:
       '@types/tough-cookie': 4.0.5
       form-data: 2.5.5
 
+  '@types/semver@7.7.1': {}
+
   '@types/ssh2@1.15.5':
     dependencies:
       '@types/node': 18.19.124
@@ -9422,7 +9434,7 @@ snapshots:
     dependencies:
       is-windows: 1.0.2
 
-  better-sqlite3@11.10.0:
+  better-sqlite3@12.4.1:
     dependencies:
       bindings: 1.5.0
       prebuild-install: 7.1.3
@@ -10015,13 +10027,13 @@ snapshots:
 
   dotenv@17.2.2: {}
 
-  drizzle-orm@0.44.5(@electric-sql/pglite@0.3.8)(@opentelemetry/api@1.9.0)(@types/better-sqlite3@7.6.13)(@types/pg@8.15.5)(better-sqlite3@11.10.0)(kysely@0.28.5)(mysql2@3.14.5)(pg@8.16.3):
+  drizzle-orm@0.44.5(@electric-sql/pglite@0.3.8)(@opentelemetry/api@1.9.0)(@types/better-sqlite3@7.6.13)(@types/pg@8.15.5)(better-sqlite3@12.4.1)(kysely@0.28.5)(mysql2@3.14.5)(pg@8.16.3):
     optionalDependencies:
       '@electric-sql/pglite': 0.3.8
       '@opentelemetry/api': 1.9.0
       '@types/better-sqlite3': 7.6.13
       '@types/pg': 8.15.5
-      better-sqlite3: 11.10.0
+      better-sqlite3: 12.4.1
       kysely: 0.28.5
       mysql2: 3.14.5
       pg: 8.16.3


### PR DESCRIPTION
This pull request introduces a version compatibility check between the ADK web UI and the ADK server, ensuring users are notified if their server version is incompatible or missing. It also updates the API to report the server version, adds supporting dependencies, and updates example values in the API documentation and DTOs for consistency.

**Version compatibility and notification:**

* Added a new `VersionCheck` React component (`apps/adk-web/components/version-check.tsx`) that checks the ADK server version using the `/health` endpoint and notifies users if the server version is missing or incompatible with the expected range (`^0.3.11`). This component is now rendered in the root layout (`apps/adk-web/app/layout.tsx`). [[1]](diffhunk://#diff-0cbfc032d436000f2c2906ef333d7290cd14bb80917b69e1fab57dc46228641bR1-R69) [[2]](diffhunk://#diff-b6225ffa7b04abc43450356af981fad2dd91da812feec2bc8bbc388293bfe51eR7) [[3]](diffhunk://#diff-b6225ffa7b04abc43450356af981fad2dd91da812feec2bc8bbc388293bfe51eR86)

**API and DTO enhancements:**

* The server `/health` endpoint now returns a `version` field, reading from its own `package.json` or environment variable, and the corresponding DTOs and OpenAPI schema have been updated to include this field. [[1]](diffhunk://#diff-a41039c86f757cf87a8855ee06022203e0784d6e5f2e5c9235eb3f14eb522c79R100) [[2]](diffhunk://#diff-dfa72342d1b5cff3131227f0665b346c5fefaf6bcb9aa5c124779d49e2527483L16-R26) [[3]](diffhunk://#diff-ac18eb4758312fa8ab66683b7d4beae0a5d6b3ef5a9d1abc3823e7a75a936a75R127-R128) [[4]](diffhunk://#diff-c0ceb715c54c0ec56e12fdb2d27f601a9f5357e7c0df7245bd628a800f066a62R821-R824)

**Configuration and dependency updates:**

* The web UI now declares its compatible server version range in `package.json` under the `adk.serverRange` key and supports overriding via `NEXT_PUBLIC_ADK_SERVER_RANGE`. Added `semver` and `@types/semver` dependencies for version range checking. [[1]](diffhunk://#diff-3f19862c6aac21372cf64fdc2dabbb92397afad12da09a46f0bf1c268da5efa7R5-R7) [[2]](diffhunk://#diff-3f19862c6aac21372cf64fdc2dabbb92397afad12da09a46f0bf1c268da5efa7R51) [[3]](diffhunk://#diff-3f19862c6aac21372cf64fdc2dabbb92397afad12da09a46f0bf1c268da5efa7R64) [[4]](diffhunk://#diff-32824c984905bb02bc7ffcef96a77addd1f1602cff71a11fbbfdd7f53ee026bbR143-R145) [[5]](diffhunk://#diff-32824c984905bb02bc7ffcef96a77addd1f1602cff71a11fbbfdd7f53ee026bbR177-R179) [[6]](diffhunk://#diff-32824c984905bb02bc7ffcef96a77addd1f1602cff71a11fbbfdd7f53ee026bbR2812-R2814)

**Documentation and example updates:**

* Updated example values for timestamps and version fields in DTOs and OpenAPI documentation for consistency and clarity. [[1]](diffhunk://#diff-ac18eb4758312fa8ab66683b7d4beae0a5d6b3ef5a9d1abc3823e7a75a936a75L50-R50) [[2]](diffhunk://#diff-ac18eb4758312fa8ab66683b7d4beae0a5d6b3ef5a9d1abc3823e7a75a936a75L70-R72) [[3]](diffhunk://#diff-ac18eb4758312fa8ab66683b7d4beae0a5d6b3ef5a9d1abc3823e7a75a936a75L88-R88) [[4]](diffhunk://#diff-ac18eb4758312fa8ab66683b7d4beae0a5d6b3ef5a9d1abc3823e7a75a936a75L107-R107) [[5]](diffhunk://#diff-c0ceb715c54c0ec56e12fdb2d27f601a9f5357e7c0df7245bd628a800f066a62L619-R619) [[6]](diffhunk://#diff-c0ceb715c54c0ec56e12fdb2d27f601a9f5357e7c0df7245bd628a800f066a62L667-R671) [[7]](diffhunk://#diff-c0ceb715c54c0ec56e12fdb2d27f601a9f5357e7c0df7245bd628a800f066a62L717-R717) [[8]](diffhunk://#diff-c0ceb715c54c0ec56e12fdb2d27f601a9f5357e7c0df7245bd628a800f066a62L780-R780)

**Minor dependency version bumps:**

* Updated `better-sqlite3` and related dependency versions in the lockfile for compatibility. [[1]](diffhunk://#diff-32824c984905bb02bc7ffcef96a77addd1f1602cff71a11fbbfdd7f53ee026bbL397-R403) [[2]](diffhunk://#diff-32824c984905bb02bc7ffcef96a77addd1f1602cff71a11fbbfdd7f53ee026bbL434-R440) [[3]](diffhunk://#diff-32824c984905bb02bc7ffcef96a77addd1f1602cff71a11fbbfdd7f53ee026bbL9425-R9437) [[4]](diffhunk://#diff-32824c984905bb02bc7ffcef96a77addd1f1602cff71a11fbbfdd7f53ee026bbL10018-R10036)