### PR TITLE
fix: wire up plugin beforeModelCallback and beforeToolCallback hooks

### DIFF
--- a/.changeset/hungry-lions-dance.md
+++ b/.changeset/hungry-lions-dance.md
@@ -2,6 +2,14 @@
 "@iqai/adk": patch
 ---
 
-Fix: Wire up plugin beforeModelCallback and beforeToolCallback hooks
+Fix: Wire up all missing plugin lifecycle callbacks
 
-The PluginManager had these callback methods defined but they were never invoked, causing plugins implementing guardrails or pre-execution logic to be silently ignored. This fix adds the missing calls in base-llm-flow.ts and functions.ts, following the same pattern used by other plugin callbacks.
+The PluginManager had several callback methods defined but never invoked, causing plugins implementing guardrails, logging, or error recovery to be silently ignored.
+
+This fix adds the missing calls for:
+- `beforeModelCallback` / `afterModelCallback` - intercept LLM requests/responses
+- `onModelErrorCallback` - handle/recover from LLM errors
+- `beforeToolCallback` / `afterToolCallback` - intercept tool execution
+- `onToolErrorCallback` - handle/recover from tool errors
+
+All 12 plugin callbacks are now properly wired up and invoked at the appropriate lifecycle points.

--- a/packages/adk/src/flows/llm-flows/base-llm-flow.ts
+++ b/packages/adk/src/flows/llm-flows/base-llm-flow.ts
@@ -580,6 +580,23 @@ export abstract class BaseLlmFlow {
 		} catch (error) {
 			llmStatus = "error";
 			telemetryService.recordError("llm", llm.model);
+
+			// Call plugin onModelErrorCallback
+			const callbackContext = new CallbackContext(invocationContext, {
+				eventActions: modelResponseEvent.actions,
+			});
+			const errorRecoveryResponse =
+				await invocationContext.pluginManager.runOnModelErrorCallback({
+					callbackContext,
+					llmRequest,
+					error: error as Error,
+				});
+
+			if (errorRecoveryResponse) {
+				yield errorRecoveryResponse;
+				return;
+			}
+
 			throw error;
 		} finally {
 			// Record LLM duration
@@ -647,6 +664,22 @@ export abstract class BaseLlmFlow {
 		llmResponse: LlmResponse,
 		modelResponseEvent: Event,
 	): Promise<LlmResponse | undefined> {
+		const callbackContext = new CallbackContext(invocationContext, {
+			eventActions: modelResponseEvent.actions,
+		});
+
+		// First, check plugin manager callbacks
+		const pluginResult =
+			await invocationContext.pluginManager.runAfterModelCallback({
+				callbackContext,
+				llmResponse,
+			});
+
+		if (pluginResult) {
+			return pluginResult;
+		}
+
+		// Then check agent-level callbacks
 		const agent = invocationContext.agent;
 
 		// Check if agent has LlmAgent-like structure
@@ -658,10 +691,6 @@ export abstract class BaseLlmFlow {
 		if (!afterCallbacks) {
 			return;
 		}
-
-		const callbackContext = new CallbackContext(invocationContext, {
-			eventActions: modelResponseEvent.actions,
-		});
 
 		for (const callback of afterCallbacks) {
 			let afterModelCallbackContent = callback({


### PR DESCRIPTION
## Summary

Fixed a bug where multiple plugin lifecycle callbacks were defined in `PluginManager` but never actually invoked. This caused plugins implementing guardrails, logging, or error recovery to be silently ignored.

Fixes #469

## Problem

The `PluginManager` class had these callback methods defined but never called:

| Callback | Purpose | Status |
|----------|---------|--------|
| `beforeModelCallback` | Intercept requests before LLM | ❌ Not called |
| `afterModelCallback` | Modify LLM responses | ❌ Not called |
| `onModelErrorCallback` | Handle/recover from LLM errors | ❌ Not called |
| `beforeToolCallback` | Intercept tool execution | ❌ Not called |
| `afterToolCallback` | Modify tool results | ❌ Not called |
| `onToolErrorCallback` | Handle/recover from tool errors | ❌ Not called |

## Solution

Added calls to all missing plugin callbacks in the appropriate places:

**`base-llm-flow.ts`:**
- `runBeforeModelCallback` in `_handleBeforeModelCallback`
- `runAfterModelCallback` in `_handleAfterModelCallback`
- `runOnModelErrorCallback` in the catch block of `_callLlmAsync`

**`functions.ts`:**
- `runBeforeToolCallback` before tool execution
- `runAfterToolCallback` after tool execution
- `runOnToolErrorCallback` in the catch block

## All 12 Plugin Callbacks Now Working

| Callback | Location | Status |
|----------|----------|--------|
| `onUserMessageCallback` | runners.ts | ✅ |
| `beforeRunCallback` | runners.ts | ✅ |
| `onEventCallback` | runners.ts | ✅ |
| `afterRunCallback` | runners.ts | ✅ |
| `beforeAgentCallback` | base-agent.ts | ✅ |
| `afterAgentCallback` | base-agent.ts | ✅ |
| `beforeModelCallback` | base-llm-flow.ts | ✅ Fixed |
| `afterModelCallback` | base-llm-flow.ts | ✅ Fixed |
| `onModelErrorCallback` | base-llm-flow.ts | ✅ Fixed |
| `beforeToolCallback` | functions.ts | ✅ Fixed |
| `afterToolCallback` | functions.ts | ✅ Fixed |
| `onToolErrorCallback` | functions.ts | ✅ Fixed |

## Test plan

- [x] Verified `beforeModelCallback` blocks requests with forbidden keywords
- [x] Build passes with no errors
- [x] Pattern is consistent with existing plugin callback usage

🤖 Generated with [Claude Code](https://claude.com/claude-code)