### PR TITLE
Fix text colour for links

### DIFF
--- a/apps/adk-web/components/ai-elements/response.tsx
+++ b/apps/adk-web/components/ai-elements/response.tsx
@@ -7,7 +7,7 @@ import { Streamdown } from "streamdown";
 type ResponseProps = ComponentProps<typeof Streamdown>;
 
 const defaultComponents = {
-	a: ({ className, children, ...props }: any) => (
+a: ({ className, children, ...props }: ComponentProps<"a">) => (
 		<a
 			className={cn(
 				"underline underline-offset-2 hover:opacity-80 transition-opacity",


### PR DESCRIPTION

Before:
<img width="754" height="153" alt="image" src="https://github.com/user-attachments/assets/34bf2b9c-eb38-493d-a307-bb9c4e7e876a" />
<img width="766" height="336" alt="image" src="https://github.com/user-attachments/assets/cb45584c-4d05-495f-ba2b-fb9f9ab290ee" />


Now:

<img width="1176" height="515" alt="CleanShot 2026-01-20 at 08 13 11" src="https://github.com/user-attachments/assets/f96a41e7-053f-4bb2-92d4-2dcaa2a7a46d" />
