### PR TITLE
docs: review and update ADK-TS Events documentation 

### DIFF
--- a/apps/docs/content/docs/framework/events/compaction.mdx
+++ b/apps/docs/content/docs/framework/events/compaction.mdx
@@ -128,6 +128,7 @@ import {
   Event,
   EventActions,
   LlmEventSummarizer,
+  LLMRegistry,
 } from "@iqai/adk";
 
 // Option 1: Use default with custom model

--- a/apps/docs/content/docs/framework/events/event-actions.mdx
+++ b/apps/docs/content/docs/framework/events/event-actions.mdx
@@ -12,15 +12,17 @@ Event Actions are the mechanism by which ADK-TS components signal side effects, 
 
 The `EventActions` class represents the actions attached to an event. It contains instructions for:
 
-- **State Changes**: Updates to session state via `stateDelta`
-- **Artifact Management**: Tracking file versions via `artifactDelta`
-- **Control Flow**: Agent transfers and escalation signals
-- **Tool Behavior**: Skipping summarization and authentication requests
+- **State changes** — updates to session state via `stateDelta`
+- **Artifact management** — tracking file versions via `artifactDelta`
+- **Control flow** — agent transfers and escalation signals
+- **Tool behavior** — skipping summarization and authentication requests
+- **Compaction** — LLM-generated summaries of event ranges via `compaction`
+- **Rewind** — session rewind markers via `rewindBeforeInvocationId`
 
 ## EventActions Structure
 
 ```typescript
-import { EventActions } from "@iqai/adk";
+import { EventActions, type EventCompaction } from "@iqai/adk";
 
 class EventActions {
   // Control tool response processing
@@ -38,6 +40,18 @@ class EventActions {
 
   // Authentication
   requestedAuthConfigs?: Record<string, any>;
+
+  // Event compaction (see Event Compaction guide)
+  compaction?: EventCompaction;
+
+  // Session rewind marker (see Rewind guide)
+  rewindBeforeInvocationId?: string;
+}
+
+interface EventCompaction {
+  startTimestamp: number;
+  endTimestamp: number;
+  compactedContent: Content;
 }
 ```
 
@@ -156,6 +170,41 @@ const actions = new EventActions({
 });
 ```
 
+### Compaction Actions
+
+When event compaction runs, the framework appends a special event whose `actions.compaction` field contains the summarized content and the timestamp range it covers. Original events in that range are filtered out when building LLM requests.
+
+```typescript
+// Created automatically by the compaction system — not typically hand-authored
+const actions = new EventActions({
+  compaction: {
+    startTimestamp: 1710000000,
+    endTimestamp: 1710003600,
+    compactedContent: {
+      role: "model",
+      parts: [{ text: "User asked about weather. Agent provided a forecast." }],
+    },
+  },
+});
+```
+
+See [Event Compaction](/docs/framework/events/compaction) for configuration and custom summarizers.
+
+### Rewind Actions
+
+When you call `runner.rewind()`, the Runner appends a rewind event with `rewindBeforeInvocationId` set to the target invocation. The event also carries `stateDelta` and `artifactDelta` values that restore session state to the rewind point.
+
+```typescript
+// Created by Runner.rewind() — restores session to a prior invocation
+const actions = new EventActions({
+  rewindBeforeInvocationId: "invocation_abc123",
+  stateDelta: { current_task: null },
+  artifactDelta: { "report.pdf": 1 },
+});
+```
+
+See [Rewind](/docs/framework/runtime/rewind) for usage and examples.
+
 ## Working with Actions in Events
 
 ### Detecting Actions
@@ -163,26 +212,38 @@ const actions = new EventActions({
 Check for actions in received events:
 
 ```typescript
-for await (const event of runner.runAsync(query, session)) {
-  if (event.actions) {
-    // Check for state changes
-    if (Object.keys(event.actions.stateDelta).length > 0) {
-      console.log("State updated:", event.actions.stateDelta);
-    }
+for await (const event of runner.runAsync({
+  userId: "user_123",
+  sessionId: "session_456",
+  newMessage: { role: "user", parts: [{ text: "Hello" }] },
+})) {
+  if (!event.actions) continue;
 
-    // Check for artifact updates
-    if (Object.keys(event.actions.artifactDelta).length > 0) {
-      console.log("Artifacts saved:", event.actions.artifactDelta);
-    }
+  if (Object.keys(event.actions.stateDelta).length > 0) {
+    console.log("State updated:", event.actions.stateDelta);
+  }
 
-    // Check for control signals
-    if (event.actions.transferToAgent) {
-      console.log(`Transferring to: ${event.actions.transferToAgent}`);
-    }
+  if (Object.keys(event.actions.artifactDelta).length > 0) {
+    console.log("Artifacts saved:", event.actions.artifactDelta);
+  }
 
-    if (event.actions.escalate) {
-      console.log("Escalation signal received");
-    }
+  if (event.actions.transferToAgent) {
+    console.log(`Transferring to: ${event.actions.transferToAgent}`);
+  }
+
+  if (event.actions.escalate) {
+    console.log("Escalation signal received");
+  }
+
+  if (event.actions.compaction) {
+    console.log("Compaction range:", [
+      event.actions.compaction.startTimestamp,
+      event.actions.compaction.endTimestamp,
+    ]);
+  }
+
+  if (event.actions.rewindBeforeInvocationId) {
+    console.log("Rewound to:", event.actions.rewindBeforeInvocationId);
   }
 }
 ```

--- a/apps/docs/content/docs/framework/events/index.mdx
+++ b/apps/docs/content/docs/framework/events/index.mdx
@@ -5,117 +5,142 @@ description: Understanding ADK-TS's event system for communication and control f
 
 import { Callout } from "fumadocs-ui/components/callout";
 import { Card, Cards } from "fumadocs-ui/components/card";
+import { Mermaid } from "@/components/mdx/mermaid";
 
-Events are the fundamental units of information flow within ADK-TS. They represent every significant occurrence during an agent's interaction lifecycle, from initial user input to the final response and all the steps in between.
+Events are the fundamental units of information flow within ADK-TS. Every user message, agent reply, tool call, state change, and control signal is represented as an `Event` — an immutable record appended to the session history and streamed to your application through `Runner.runAsync()`.
 
-## What Events Are
+## What events represent
 
-An `Event` in ADK-TS is an immutable record representing a specific point in the agent's execution. It captures:
+An `Event` captures a single point in an agent interaction:
 
-- **User messages** - Direct input from end users
-- **Agent replies** - Responses and actions from agents
-- **Tool interactions** - Function calls and their results
-- **State changes** - Updates to session state and artifacts
-- **Control signals** - Flow control and error conditions
+- **User messages** — input appended to the session
+- **Agent replies** — model text, tool calls, or code execution results
+- **Tool interactions** — function calls and their responses
+- **State and artifact changes** — carried in `event.actions`
+- **Control signals** — agent transfers, escalation, compaction, and rewind markers
 
 <Callout type="info">
 
-Events serve as the standard message format between the user interface, the
-`Runner`, agents, the LLM, and tools. Everything flows as an `Event`.
+Events are the standard message format between the UI, the `Runner`, agents, the LLM, and tools. The sequence stored in `session.events` is the complete, chronological history of an interaction.
 
 </Callout>
 
-## Event Structure
+## Event structure
 
-Events build upon the basic `LlmResponse` structure by adding essential ADK-TS-specific metadata:
+`Event` extends `LlmResponse`, inheriting LLM response fields and adding ADK-TS-specific metadata:
 
 ```typescript
 import { Event, EventActions } from "@iqai/adk";
 
+// Event extends LlmResponse
 class Event extends LlmResponse {
-  // Core identification
-  id: string; // Unique event identifier
-  invocationId: string; // ID for the whole interaction run
-  author: string; // 'user' or agent name
-  timestamp: number; // Creation time (seconds since epoch)
+  // ADK-TS identification
+  id: string; // Unique event ID (8-char hex)
+  invocationId: string; // ID for the current invocation run
+  author: string; // "user" or the agent name
+  timestamp: number; // Unix timestamp in seconds
 
-  // Content and flow control
-  content?: any; // Event payload (text, function calls, etc.)
+  // Inherited from LlmResponse
+  content?: Content; // Text, function calls, function responses, etc.
   partial?: boolean; // True for streaming chunks
-  turnComplete?: boolean; // True when agent's turn is finished
+  turnComplete?: boolean; // True when the model turn is finished
+  errorCode?: string;
+  errorMessage?: string;
+  usageMetadata?: GenerateContentResponseUsageMetadata;
+  groundingMetadata?: GroundingMetadata;
+  interrupted?: boolean;
+  finishReason?: string;
 
-  // ADK-TS-specific features
-  actions: EventActions; // Side-effects & control signals
-  longRunningToolIds?: Set<string>; // Background tool execution
-  branch?: string; // Hierarchy path for multi-agent scenarios
+  // ADK-TS extensions
+  actions: EventActions; // Side effects and control signals
+  longRunningToolIds?: Set<string>; // IDs of background tool calls
+  branch?: string; // Multi-agent hierarchy path (e.g. "parent.child")
 
   // Helper methods
   isFinalResponse(): boolean;
-  getFunctionCalls(): any[];
-  getFunctionResponses(): any[];
+  getFunctionCalls(): FunctionCall[];
+  getFunctionResponses(): FunctionResponse[];
+  hasTrailingCodeExecutionResult(): boolean;
+  static newId(): string;
 }
 ```
 
-## Event Types
+### When is a response final?
 
-### User Events
+`isFinalResponse()` tells you when an event is ready to display to the user. It returns `true` when:
 
-Events with `author: 'user'` represent direct input from the end-user.
-
-### Agent Events
-
-Events with `author: 'AgentName'` represent output or actions from a specific agent.
-
-### Tool Events
-
-Events containing function calls or responses for tool execution.
-
-### Control Events
-
-Events carrying state changes, control flow signals, or configuration updates.
-
-## Core Concepts
-
-<Cards>
-  <Card
-    title="Event Actions"
-    description="Understanding state management, artifact tracking, and control flow signals"
-    href="/docs/framework/events/event-actions"
-  />
-  <Card
-    title="Working with Events"
-    description="Practical patterns for processing and handling events in your applications"
-    href="/docs/framework/events/working-with-events"
-  />
-  <Card
-    title="Event Compaction"
-    description="Automatically manage long session histories with LLM-generated summaries"
-    href="/docs/framework/events/compaction"
-  />
-  <Card
-    title="Event Streaming"
-    description="Real-time event processing and streaming patterns for responsive UIs"
-    href="/docs/framework/events/streaming"
-  />
-  <Card
-    title="Event Patterns"
-    description="Architectural patterns and best practices for event-driven applications"
-    href="/docs/framework/events/patterns"
-  />
-</Cards>
-
-## Quick Example
-
-Here's a basic example of processing events from an agent:
+1. `actions.skipSummarization` is set, or `longRunningToolIds` is present — the client should surface the result directly
+2. Otherwise, when the event has no function calls or responses, is not a partial stream chunk, and has no trailing code execution result
 
 ```typescript
-import { LlmAgent, Event } from "@iqai/adk";
+// Simplified logic from the framework
+event.isFinalResponse() === event.actions.skipSummarization ||
+  !!event.longRunningToolIds ||
+  (event.getFunctionCalls().length === 0 &&
+    event.getFunctionResponses().length === 0 &&
+    !event.partial &&
+    !event.hasTrailingCodeExecutionResult());
+```
 
-// Process events from an agent interaction
-for await (const event of runner.runAsync(query, session)) {
+## Event flow
+
+<Mermaid
+  chart={`
+flowchart LR
+    UI["Client / UI"]
+    Runner["Runner.runAsync()"]
+    Agent["Agent"]
+    LLM["LLM"]
+    Tools["Tools"]
+    Session["session.events"]
+
+    UI -->|"newMessage"| Runner
+    Runner --> Agent
+    Agent --> LLM
+    Agent --> Tools
+    LLM -->|"yield Event"| Agent
+    Tools -->|"yield Event"| Agent
+    Agent -->|"yield Event"| Runner
+    Runner -->|"persist + stream"| Session
+    Runner -->|"AsyncGenerator Event"| UI
+
+`}
+/>
+
+1. **User input** — the Runner appends a user event to the session
+2. **Agent processing** — the agent yields events with text, tool calls, or partial stream chunks
+3. **Tool execution** — tool results are yielded as events with `functionResponse` parts
+4. **State updates** — changes are recorded in `event.actions.stateDelta`
+5. **Final response** — `isFinalResponse()` returns `true` on the event ready for display
+
+For the full Runner processing pipeline, see [Runner & Event Processing](/docs/framework/runtime/runner-events).
+
+## Processing events
+
+Use `Runner.runAsync()` to stream events. Pass a `userId`, `sessionId`, and the user's message:
+
+```typescript
+import { Runner, InMemorySessionService, LlmAgent } from "@iqai/adk";
+
+const agent = new LlmAgent({
+  name: "assistant",
+  model: "gemini-2.5-flash",
+  instruction: "You are a helpful assistant.",
+});
+
+const runner = new Runner({
+  appName: "my-app",
+  agent,
+  sessionService: new InMemorySessionService(),
+});
+
+for await (const event of runner.runAsync({
+  userId: "user_123",
+  sessionId: "session_456",
+  newMessage: { role: "user", parts: [{ text: "What's the weather?" }] },
+})) {
   console.log(`Event from: ${event.author}`);
 
-  // Handle different event types
   if (event.content?.parts?.[0]?.text) {
     console.log("Text:", event.content.parts[0].text);
   }
@@ -124,7 +149,10 @@ for await (const event of runner.runAsync(query, session)) {
     console.log("Tool calls:", event.getFunctionCalls());
   }
 
-  if (event.actions?.stateDelta) {
+  if (
+    event.actions?.stateDelta &&
+    Object.keys(event.actions.stateDelta).length > 0
+  ) {
     console.log("State changes:", event.actions.stateDelta);
   }
 
@@ -134,44 +162,47 @@ for await (const event of runner.runAsync(query, session)) {
 }
 ```
 
-## Event Flow in ADK-TS
-
-Events enable communication throughout the ADK-TS system:
-
-1. **User Input** → Creates user event
-2. **Agent Processing** → Generates agent events with text or tool calls
-3. **Tool Execution** → Creates tool response events
-4. **State Updates** → Tracked via event actions
-5. **Final Response** → Delivered as final event ready for display
-
 <Callout type="info">
 
-The sequence of events recorded in `session.events` provides a complete,
-chronological history of an interaction, invaluable for debugging, auditing,
-and understanding agent behavior.
+For text-only streaming without handling full `Event` objects, use the helpers in `@iqai/adk/utils`: `textStreamFrom()`, `collectTextFrom()`, and `streamTextWithFinalEvent()`. See [Event Streaming](/docs/framework/events/streaming).
 
 </Callout>
 
-## Key Features
+## Event categories
 
-### State Management
+| Category       | How to identify                                               | Typical content                             |
+| -------------- | ------------------------------------------------------------- | ------------------------------------------- |
+| User events    | `author === "user"`                                           | User message text                           |
+| Agent events   | `author` is an agent name                                     | Model text, tool calls                      |
+| Tool events    | `getFunctionCalls()` or `getFunctionResponses()` is non-empty | Tool request or result                      |
+| Control events | Non-empty `actions` fields                                    | State deltas, transfers, compaction, rewind |
 
-Events carry state changes through `actions.stateDelta`, allowing components to update session state reactively.
+## Guides in this section
 
-### Artifact Tracking
-
-File operations and artifact versions are tracked through `actions.artifactDelta`.
-
-### Control Flow
-
-Events can signal agent transfers (`transferToAgent`), loop termination (`escalate`), and other control flow changes.
-
-### Streaming Support
-
-Events support real-time streaming with `partial` flags for progressive content delivery.
-
-### Error Handling
-
-Events inherit error properties (`errorCode`, `errorMessage`) for comprehensive error tracking.
-
-Events are the backbone of the ADK-TS communication system, enabling powerful features like state management, tool orchestration, and complex agent workflows. Explore the detailed guides above to learn how to leverage events effectively in your applications.
+<Cards>
+  <Card
+    title="Event Actions"
+    description="State management, artifact tracking, compaction, rewind, and control flow signals"
+    href="/docs/framework/events/event-actions"
+  />
+  <Card
+    title="Working with Events"
+    description="Practical patterns for processing and filtering events in your applications"
+    href="/docs/framework/events/working-with-events"
+  />
+  <Card
+    title="Event Compaction"
+    description="Automatically manage long session histories with LLM-generated summaries"
+    href="/docs/framework/events/compaction"
+  />
+  <Card
+    title="Event Streaming"
+    description="Real-time streaming with partial events and utility helpers"
+    href="/docs/framework/events/streaming"
+  />
+  <Card
+    title="Event Patterns"
+    description="Architectural patterns for event-driven agent applications"
+    href="/docs/framework/events/patterns"
+  />
+</Cards>

--- a/apps/docs/content/docs/framework/events/patterns.mdx
+++ b/apps/docs/content/docs/framework/events/patterns.mdx
@@ -8,6 +8,12 @@ import { Tabs, Tab } from "fumadocs-ui/components/tabs";
 
 This guide covers common architectural patterns for building robust, scalable event-driven applications with ADK-TS.
 
+<Callout type="info">
+
+The examples below use simplified APIs for clarity. In production, stream events via `Runner.runAsync({ userId, sessionId, newMessage })` — see [Working with Events](/docs/framework/events/working-with-events).
+
+</Callout>
+
 ## Architectural Patterns
 
 ### Event Sourcing

--- a/apps/docs/content/docs/framework/events/streaming.mdx
+++ b/apps/docs/content/docs/framework/events/streaming.mdx
@@ -6,526 +6,267 @@ description: Real-time event processing and streaming patterns in ADK-TS
 import { Callout } from "fumadocs-ui/components/callout";
 import { Tabs, Tab } from "fumadocs-ui/components/tabs";
 
-ADK-TS event streaming enables real-time interaction with agents, allowing your applications to process and display responses as they're generated rather than waiting for complete responses.
+ADK-TS streams events from `Runner.runAsync()` as an `AsyncGenerator<Event>`. Streaming lets your application display partial model output, tool activity, and state changes as they happen instead of waiting for the full response.
 
-## Understanding Streaming Events
+## Streaming-related event fields
 
-Streaming events allow for progressive content delivery, improving user experience by showing partial results immediately.
+Events inherit these fields from `LlmResponse`:
 
-### Event Properties for Streaming
+| Field           | Type      | Description                                 |
+| --------------- | --------- | ------------------------------------------- |
+| `partial`       | `boolean` | `true` on incremental streaming chunks      |
+| `turnComplete`  | `boolean` | `true` when the model turn is finished      |
+| `content`       | `Content` | Text, function calls, or function responses |
+| `usageMetadata` | `object`  | Token usage — typically on the final chunk  |
 
-Key properties that control streaming behavior:
+Use `event.isFinalResponse()` to detect when an event is ready to display. Partial chunks (`partial: true`) are never final responses.
+
+<Callout type="info">
+
+The streaming helpers in `@iqai/adk/utils` only yield text from events where `partial` is `true`. For tool calls, metadata, or action handling, iterate the full event stream from `runAsync()` directly.
+
+</Callout>
+
+## Full event stream
+
+The primary streaming API is `Runner.runAsync()`:
 
 ```typescript
-interface Event {
-  partial?: boolean; // True for incomplete streaming chunks
-  turnComplete?: boolean; // True when the agent's turn is finished
-  content?: any; // Contains the partial or complete content
-  // ... other properties
+import { Runner, InMemorySessionService, LlmAgent } from "@iqai/adk";
+
+const runner = new Runner({
+  appName: "my-app",
+  agent: new LlmAgent({
+    name: "assistant",
+    model: "gemini-2.5-flash",
+    instruction: "You are a helpful assistant.",
+  }),
+  sessionService: new InMemorySessionService(),
+});
+
+for await (const event of runner.runAsync({
+  userId: "user_123",
+  sessionId: "session_456",
+  newMessage: { role: "user", parts: [{ text: "Tell me a story" }] },
+})) {
+  if (event.partial && event.content?.parts?.[0]?.text) {
+    process.stdout.write(event.content.parts[0].text);
+  }
+
+  if (event.isFinalResponse()) {
+    console.log("\nDone. Tokens:", event.usageMetadata?.totalTokenCount);
+  }
 }
 ```
 
-## Basic Streaming Patterns
+Enable SSE streaming mode via `RunConfig` when needed — see [Run Config](/docs/framework/runtime/run-config).
 
-### Simple Text Streaming
+## Streaming utilities
 
-Handle streaming text responses:
+For text-only use cases, ADK-TS provides helpers in `@iqai/adk/utils`:
+
+<Tabs items={["textStreamFrom", "collectTextFrom", "streamTextWithFinalEvent"]}>
+<Tab value="textStreamFrom">
+
+Yields text deltas from partial events as they arrive:
 
 ```typescript
-async function handleStreamingResponse(runner, query, session) {
+import { textStreamFrom } from "@iqai/adk/utils";
+
+const events = runner.runAsync({
+  userId: "user_123",
+  sessionId: "session_456",
+  newMessage: { role: "user", parts: [{ text: "Tell me a story" }] },
+});
+
+for await (const text of textStreamFrom(events)) {
+  process.stdout.write(text);
+}
+```
+
+</Tab>
+
+<Tab value="collectTextFrom">
+
+Accumulates all partial text and returns the complete string:
+
+```typescript
+import { collectTextFrom } from "@iqai/adk/utils";
+
+const events = runner.runAsync({
+  userId: "user_123",
+  sessionId: "session_456",
+  newMessage: { role: "user", parts: [{ text: "Hello" }] },
+});
+
+const fullText = await collectTextFrom(events);
+console.log(fullText);
+```
+
+</Tab>
+
+<Tab value="streamTextWithFinalEvent">
+
+Streams text while also giving you the final `Event` for metadata and tool calls:
+
+```typescript
+import { streamTextWithFinalEvent } from "@iqai/adk/utils";
+
+const events = runner.runAsync({
+  userId: "user_123",
+  sessionId: "session_456",
+  newMessage: { role: "user", parts: [{ text: "Calculate 2+2" }] },
+});
+
+const { textStream, finalEvent } = streamTextWithFinalEvent(events);
+
+for await (const text of textStream) {
+  process.stdout.write(text);
+}
+
+const final = await finalEvent;
+console.log("Tool calls:", final?.getFunctionCalls());
+console.log("Tokens:", final?.usageMetadata?.totalTokenCount);
+```
+
+</Tab>
+</Tabs>
+
+## Accumulating partial text manually
+
+When you need custom UI logic, accumulate partial chunks yourself and use `isFinalResponse()` to finalize:
+
+```typescript
+async function handleStreamingResponse(
+  runner: Runner,
+  userId: string,
+  sessionId: string,
+  message: string,
+) {
   let accumulatedText = "";
 
-  for await (const event of runner.runAsync(query, session)) {
-    if (event.content?.parts?.[0]?.text) {
-      if (event.partial) {
-        // Partial chunk - accumulate and display
-        accumulatedText += event.content.parts[0].text;
-        displayPartialText(accumulatedText);
-      } else {
-        // Complete chunk
-        accumulatedText += event.content.parts[0].text;
-        if (event.isFinalResponse()) {
-          displayFinalText(accumulatedText);
-          accumulatedText = ""; // Reset for next response
-        }
-      }
+  for await (const event of runner.runAsync({
+    userId,
+    sessionId,
+    newMessage: { role: "user", parts: [{ text: message }] },
+  })) {
+    if (event.partial && event.content?.parts?.[0]?.text) {
+      accumulatedText += event.content.parts[0].text;
+      displayPartialText(accumulatedText);
+    }
+
+    if (event.isFinalResponse() && event.content?.parts?.[0]?.text) {
+      accumulatedText += event.content.parts[0].text || "";
+      displayFinalText(accumulatedText.trim());
+      accumulatedText = "";
     }
   }
 }
 ```
 
-### Progressive UI Updates
+## React hook example
 
-<Tabs items={['React Hook', 'Vanilla JS', 'Vue Composition']}>
-<Tab value="React Hook">
 ```typescript
-import { useState, useEffect } from 'react';
+import { useState, useEffect } from "react";
+import type { Event, Runner } from "@iqai/adk";
+import { textStreamFrom } from "@iqai/adk/utils";
 
-function useEventStream(runner, query, session) {
-const [streamingText, setStreamingText] = useState('');
-const [events, setEvents] = useState<Event[]>([]);
-const [isStreaming, setIsStreaming] = useState(false);
+function useEventStream(
+  runner: Runner,
+  userId: string,
+  sessionId: string,
+  message: string,
+) {
+  const [streamingText, setStreamingText] = useState("");
+  const [events, setEvents] = useState<Event[]>([]);
+  const [isStreaming, setIsStreaming] = useState(false);
 
-useEffect(() => {
-let currentText = '';
+  useEffect(() => {
+    let cancelled = false;
 
     async function processStream() {
       setIsStreaming(true);
+      setStreamingText("");
+      setEvents([]);
+
+      const eventStream = runner.runAsync({
+        userId,
+        sessionId,
+        newMessage: { role: "user", parts: [{ text: message }] },
+      });
+
+      // Tee the stream: collect events and extract text
+      const events: Event[] = [];
+      async function* teeEvents() {
+        for await (const event of eventStream) {
+          events.push(event);
+          yield event;
+        }
+      }
 
       try {
-        for await (const event of runner.runAsync(query, session)) {
-          setEvents(prev => [...prev, event]);
-
-          if (event.content?.parts?.[0]?.text) {
-            if (event.partial) {
-              currentText += event.content.parts[0].text;
-              setStreamingText(currentText);
-            } else if (event.isFinalResponse()) {
-              currentText += event.content.parts[0].text;
-              setStreamingText(currentText);
-              currentText = ''; // Reset for next response
-            }
-          }
+        for await (const text of textStreamFrom(teeEvents())) {
+          if (cancelled) return;
+          setStreamingText(prev => prev + text);
         }
+        if (!cancelled) setEvents(events);
       } finally {
-        setIsStreaming(false);
+        if (!cancelled) setIsStreaming(false);
       }
     }
 
     processStream();
-
-}, [query]);
-
-return { streamingText, events, isStreaming };
-}
-
-````
-</Tab>
-
-<Tab value="Vanilla JS">
-```typescript
-class StreamingRenderer {
-  private container: HTMLElement;
-  private currentElement: HTMLElement | null = null;
-
-  constructor(containerId: string) {
-    this.container = document.getElementById(containerId)!;
-  }
-
-  async processStream(runner, query, session) {
-    let currentText = '';
-
-    for await (const event of runner.runAsync(query, session)) {
-      if (event.content?.parts?.[0]?.text) {
-        if (event.partial) {
-          currentText += event.content.parts[0].text;
-          this.updateCurrentElement(currentText);
-        } else if (event.isFinalResponse()) {
-          currentText += event.content.parts[0].text;
-          this.finalizeCurrentElement(currentText);
-          this.createNewElement();
-          currentText = '';
-        }
-      }
-    }
-  }
-
-  private updateCurrentElement(text: string) {
-    if (!this.currentElement) {
-      this.createNewElement();
-    }
-    this.currentElement!.textContent = text;
-  }
-
-  private createNewElement() {
-    this.currentElement = document.createElement('div');
-    this.currentElement.className = 'streaming-text';
-    this.container.appendChild(this.currentElement);
-  }
-
-  private finalizeCurrentElement(text: string) {
-    if (this.currentElement) {
-      this.currentElement.textContent = text;
-      this.currentElement.className = 'final-text';
-    }
-  }
-}
-````
-
-</Tab>
-
-<Tab value="Vue Composition">
-```typescript
-import { ref, onMounted } from 'vue';
-
-export function useEventStream(runner, query, session) {
-  const streamingText = ref('');
-  const events = ref<Event[]>([]);
-  const isStreaming = ref(false);
-
-const processStream = async () => {
-let currentText = '';
-isStreaming.value = true;
-
-    try {
-      for await (const event of runner.runAsync(query, session)) {
-        events.value.push(event);
-
-        if (event.content?.parts?.[0]?.text) {
-          if (event.partial) {
-            currentText += event.content.parts[0].text;
-            streamingText.value = currentText;
-          } else if (event.isFinalResponse()) {
-            currentText += event.content.parts[0].text;
-            streamingText.value = currentText;
-            currentText = '';
-          }
-        }
-      }
-    } finally {
-      isStreaming.value = false;
-    }
-
-};
-
-onMounted(processStream);
-
-return { streamingText, events, isStreaming };
-}
-
-````
-</Tab>
-</Tabs>
-
-## Advanced Streaming Patterns
-
-### Multi-Stream Handling
-
-Handle multiple concurrent streams:
-
-```typescript
-class MultiStreamManager {
-  private streams = new Map<string, StreamState>();
-
-  interface StreamState {
-    text: string;
-    isActive: boolean;
-    lastUpdate: number;
-  }
-
-  async processEvent(event: Event) {
-    const streamId = event.invocationId;
-
-    if (!this.streams.has(streamId)) {
-      this.streams.set(streamId, {
-        text: '',
-        isActive: true,
-        lastUpdate: Date.now()
-      });
-    }
-
-    const stream = this.streams.get(streamId)!;
-
-    if (event.content?.parts?.[0]?.text) {
-      if (event.partial) {
-        stream.text += event.content.parts[0].text;
-        stream.lastUpdate = Date.now();
-        this.onStreamUpdate(streamId, stream.text);
-      } else if (event.isFinalResponse()) {
-        stream.text += event.content.parts[0].text;
-        stream.isActive = false;
-        this.onStreamComplete(streamId, stream.text);
-      }
-    }
-  }
-
-  private onStreamUpdate(streamId: string, text: string) {
-    // Update UI for specific stream
-    console.log(`Stream ${streamId} updated:`, text);
-  }
-
-  private onStreamComplete(streamId: string, text: string) {
-    // Finalize stream display
-    console.log(`Stream ${streamId} completed:`, text);
-    this.streams.delete(streamId);
-  }
-}
-````
-
-### Buffered Streaming
-
-Implement buffering for smoother display:
-
-```typescript
-class BufferedStreamRenderer {
-  private buffer: string[] = [];
-  private isDisplaying = false;
-  private displayInterval = 50; // ms
-
-  addChunk(text: string) {
-    this.buffer.push(text);
-    this.startDisplayLoop();
-  }
-
-  private startDisplayLoop() {
-    if (this.isDisplaying) return;
-    this.isDisplaying = true;
-
-    const displayNext = () => {
-      if (this.buffer.length > 0) {
-        const chunk = this.buffer.shift()!;
-        this.displayChunk(chunk);
-        setTimeout(displayNext, this.displayInterval);
-      } else {
-        this.isDisplaying = false;
-      }
+    return () => {
+      cancelled = true;
     };
+  }, [runner, userId, sessionId, message]);
 
-    displayNext();
-  }
+  return { streamingText, events, isStreaming };
+}
+```
 
-  private displayChunk(chunk: string) {
-    // Implement smooth character-by-character display
-    const element = document.getElementById("output");
-    if (element) {
-      element.textContent += chunk;
-    }
+## Showing processing status
+
+Track non-text events to update loading indicators:
+
+```typescript
+function updateStatusFromEvent(event: Event) {
+  if (event.partial) {
+    setStatus("streaming", "Receiving response...");
+  } else if (event.getFunctionCalls().length > 0) {
+    setStatus("processing", "Using tools...");
+  } else if (event.getFunctionResponses().length > 0) {
+    setStatus("processing", "Processing results...");
+  } else if (event.isFinalResponse()) {
+    setStatus("complete", "Response complete");
   }
 }
 ```
 
-## Event Queue Management
+## Error handling
 
-### Priority Queue
-
-Handle events with different priorities:
+Events can carry `errorCode` and `errorMessage` from the LLM layer. Check these before processing content:
 
 ```typescript
-class PriorityEventQueue {
-  private queues = {
-    high: [] as Event[],
-    normal: [] as Event[],
-    low: [] as Event[],
-  };
-
-  enqueue(event: Event, priority: "high" | "normal" | "low" = "normal") {
-    this.queues[priority].push(event);
-    this.processNext();
+for await (const event of runner.runAsync({ userId, sessionId, newMessage })) {
+  if (event.errorCode) {
+    showError(event.errorMessage ?? event.errorCode);
+    continue;
   }
 
-  private processNext() {
-    const event = this.dequeue();
-    if (event) {
-      this.handleEvent(event);
-      // Schedule next processing
-      setImmediate(() => this.processNext());
-    }
-  }
-
-  private dequeue(): Event | null {
-    if (this.queues.high.length > 0) {
-      return this.queues.high.shift()!;
-    }
-    if (this.queues.normal.length > 0) {
-      return this.queues.normal.shift()!;
-    }
-    if (this.queues.low.length > 0) {
-      return this.queues.low.shift()!;
-    }
-    return null;
-  }
-
-  private handleEvent(event: Event) {
-    // Process the event based on its type
-    if (event.partial) {
-      this.handleStreamingEvent(event);
-    } else if (event.isFinalResponse()) {
-      this.handleFinalEvent(event);
-    }
-  }
-}
-```
-
-## Real-Time Features
-
-### Live Status Updates
-
-Show real-time processing status:
-
-```typescript
-class LiveStatusManager {
-  private statusElement: HTMLElement;
-  private currentStatus = "idle";
-
-  constructor(elementId: string) {
-    this.statusElement = document.getElementById(elementId)!;
-  }
-
-  updateFromEvent(event: Event) {
-    if (event.partial) {
-      this.setStatus("streaming", "Receiving response...");
-    } else if (event.getFunctionCalls().length > 0) {
-      this.setStatus("processing", "Using tools...");
-    } else if (event.getFunctionResponses().length > 0) {
-      this.setStatus("processing", "Processing results...");
-    } else if (event.isFinalResponse()) {
-      this.setStatus("complete", "Response complete");
-      setTimeout(() => this.setStatus("idle", "Ready"), 2000);
-    }
-  }
-
-  private setStatus(status: string, message: string) {
-    this.currentStatus = status;
-    this.statusElement.textContent = message;
-    this.statusElement.className = `status ${status}`;
-  }
-}
-```
-
-### Typing Indicators
-
-Show when agents are "thinking":
-
-```typescript
-class TypingIndicator {
-  private element: HTMLElement;
-  private timer: NodeJS.Timeout | null = null;
-
-  constructor(elementId: string) {
-    this.element = document.getElementById(elementId)!;
-  }
-
-  show(agentName: string) {
-    this.element.textContent = `${agentName} is thinking...`;
-    this.element.style.display = "block";
-    this.startAnimation();
-  }
-
-  hide() {
-    this.element.style.display = "none";
-    this.stopAnimation();
-  }
-
-  private startAnimation() {
-    let dots = "";
-    this.timer = setInterval(() => {
-      dots = dots.length >= 3 ? "" : dots + ".";
-      this.element.textContent =
-        this.element.textContent?.replace(/\.+$/, "") + dots;
-    }, 500);
-  }
-
-  private stopAnimation() {
-    if (this.timer) {
-      clearInterval(this.timer);
-      this.timer = null;
-    }
-  }
-}
-```
-
-## Performance Optimization
-
-### Debounced Updates
-
-Reduce UI update frequency:
-
-```typescript
-function debounce<T extends (...args: any[]) => void>(
-  func: T,
-  delay: number,
-): (...args: Parameters<T>) => void {
-  let timeoutId: NodeJS.Timeout;
-
-  return (...args: Parameters<T>) => {
-    clearTimeout(timeoutId);
-    timeoutId = setTimeout(() => func(...args), delay);
-  };
-}
-
-class OptimizedStreamRenderer {
-  private debouncedUpdate = debounce((text: string) => {
-    this.updateUI(text);
-  }, 16); // ~60fps
-
-  handleStreamingEvent(event: Event) {
-    if (event.partial && event.content?.parts?.[0]?.text) {
-      this.debouncedUpdate(event.content.parts[0].text);
-    }
-  }
-
-  private updateUI(text: string) {
-    // Expensive UI update operation
-    document.getElementById("output")!.textContent = text;
-  }
-}
-```
-
-### Memory Management
-
-Handle large streams efficiently:
-
-```typescript
-class MemoryEfficientStream {
-  private maxEvents = 1000;
-  private events: Event[] = [];
-
-  addEvent(event: Event) {
-    this.events.push(event);
-
-    // Keep only recent events
-    if (this.events.length > this.maxEvents) {
-      this.events = this.events.slice(-this.maxEvents);
-    }
-  }
-
-  getRecentEvents(count: number = 100): Event[] {
-    return this.events.slice(-count);
-  }
-
-  cleanup() {
-    this.events = [];
-  }
-}
-```
-
-## Error Handling in Streams
-
-### Stream Recovery
-
-Handle stream interruptions gracefully:
-
-```typescript
-async function robustStreamProcessing(runner, query, session) {
-  let retries = 0;
-  const maxRetries = 3;
-
-  while (retries < maxRetries) {
-    try {
-      for await (const event of runner.runAsync(query, session)) {
-        await processEvent(event);
-      }
-      break; // Success, exit retry loop
-    } catch (error) {
-      retries++;
-      console.warn(`Stream interrupted (attempt ${retries}):`, error);
-
-      if (retries < maxRetries) {
-        await new Promise(resolve => setTimeout(resolve, 1000 * retries));
-      } else {
-        console.error("Max retries exceeded, stream failed");
-        throw error;
-      }
-    }
-  }
+  // Normal streaming handling...
 }
 ```
 
 <Callout type="warn">
 
-When implementing streaming, always handle network interruptions and provide
-fallback mechanisms for critical functionality.
+Network interruptions during streaming require application-level retry logic. The Runner does not automatically resume a partial stream — start a new invocation if the connection drops.
 
 </Callout>
 
-Event streaming enables responsive, real-time agent interactions that significantly improve user experience in ADK-TS applications.
+## Related topics
+
+- [Overview](/docs/framework/events) — event structure and `isFinalResponse()` logic
+- [Working with Events](/docs/framework/events/working-with-events) — filtering and action handling
+- [Runner & Event Processing](/docs/framework/runtime/runner-events) — how the Runner processes the event loop
+- [Run Config](/docs/framework/runtime/run-config) — streaming mode configuration

--- a/apps/docs/content/docs/framework/events/working-with-events.mdx
+++ b/apps/docs/content/docs/framework/events/working-with-events.mdx
@@ -52,6 +52,7 @@ Access different types of content from events:
 
 <Tabs items={['Text Content', 'Function Calls', 'Function Responses']}>
 <Tab value="Text Content">
+
 ```typescript
 function extractText(event: Event): string | null {
   if (event.content?.parts?.[0]?.text) {
@@ -63,10 +64,10 @@ function extractText(event: Event): string | null {
 // Usage
 const text = extractText(event);
 if (text) {
-console.log("Message:", text);
+  console.log("Message:", text);
 }
+```
 
-````
 </Tab>
 
 <Tab value="Function Calls">
@@ -74,9 +75,9 @@ console.log("Message:", text);
 function processFunctionCalls(event: Event) {
   const calls = event.getFunctionCalls();
 
-  for (const call of calls) {
-    console.log(`Tool requested: ${call.name}`);
-    console.log(`Arguments:`, call.args);
+for (const call of calls) {
+console.log(`Tool requested: ${call.name}`);
+console.log(`Arguments:`, call.args);
 
     // Dispatch based on tool name
     switch (call.name) {
@@ -89,8 +90,10 @@ function processFunctionCalls(event: Event) {
       default:
         console.log(`Unknown tool: ${call.name}`);
     }
-  }
+
 }
+}
+
 ````
 
 </Tab>
@@ -106,14 +109,13 @@ console.log(`Tool ${response.name} returned:`, response.response);
     // Handle specific tool responses
     if (response.name === 'search') {
       displaySearchResults(response.response);
-    } else if (response.name === 'sendEmail') {
+    } else if (response.name === "sendEmail") {
       showEmailConfirmation(response.response);
     }
-
+  }
 }
-}
-
 ````
+
 </Tab>
 </Tabs>
 
@@ -124,38 +126,43 @@ console.log(`Tool ${response.name} returned:`, response.response);
 Use the built-in helper to identify display-ready events:
 
 ```typescript
-async function processAgentConversation(runner, query, session) {
-  let streamingText = '';
+async function processAgentConversation(
+  runner: Runner,
+  userId: string,
+  sessionId: string,
+  message: string,
+) {
+  let streamingText = "";
 
-  for await (const event of runner.runAsync(query, session)) {
+  for await (const event of runner.runAsync({
+    userId,
+    sessionId,
+    newMessage: { role: "user", parts: [{ text: message }] },
+  })) {
     // Handle streaming content
     if (event.partial && event.content?.parts?.[0]?.text) {
       streamingText += event.content.parts[0].text;
-      updateUI(streamingText); // Real-time updates
+      updateUI(streamingText);
     }
 
     // Handle final responses
     if (event.isFinalResponse()) {
       if (event.content?.parts?.[0]?.text) {
-        // Complete text response
-        const finalText = streamingText + (event.content.parts[0].text || '');
+        const finalText = streamingText + (event.content.parts[0].text || "");
         displayFinalMessage(finalText.trim());
-        streamingText = ''; // Reset
+        streamingText = "";
       } else if (event.actions?.skipSummarization) {
-        // Raw tool result
         const toolResponse = event.getFunctionResponses()[0];
         displayToolResult(toolResponse.response);
-      } else if (event.longRunningToolIds) {
-        // Background process
+      } else if (event.longRunningToolIds?.size) {
         showProcessingIndicator();
       }
     }
 
-    // Handle actions
     processEventActions(event);
   }
 }
-````
+```
 
 ### Custom Event Filters
 
@@ -344,8 +351,19 @@ function handleEventError(event: Event) {
 
 ```typescript
 import { useState, useEffect } from "react";
+import type { Event, Runner } from "@iqai/adk";
 
-function ConversationComponent({ runner, query, session }) {
+function ConversationComponent({
+  runner,
+  userId,
+  sessionId,
+  message,
+}: {
+  runner: Runner;
+  userId: string;
+  sessionId: string;
+  message: string;
+}) {
   const [events, setEvents] = useState<Event[]>([]);
   const [isLoading, setIsLoading] = useState(false);
 
@@ -355,9 +373,13 @@ function ConversationComponent({ runner, query, session }) {
       const newEvents: Event[] = [];
 
       try {
-        for await (const event of runner.runAsync(query, session)) {
+        for await (const event of runner.runAsync({
+          userId,
+          sessionId,
+          newMessage: { role: "user", parts: [{ text: message }] },
+        })) {
           newEvents.push(event);
-          setEvents([...newEvents]); // Update UI with each event
+          setEvents([...newEvents]);
         }
       } finally {
         setIsLoading(false);
@@ -365,7 +387,7 @@ function ConversationComponent({ runner, query, session }) {
     }
 
     runConversation();
-  }, [query]);
+  }, [message, runner, sessionId, userId]);
 
   return (
     <div>


### PR DESCRIPTION
## Summary
- Reviewed the Events documentation section against the current `@iqai/adk` source
- Updated Event/EventActions API references, runAsync examples, and streaming utilities
- Documented compaction and rewind action types that were missing from event-actions.mdx

Fixes #702

## Test plan
- [x] `pnpm install` in monorepo root
- [x] `pnpm build` in `apps/docs`
- [ ] Preview updated pages locally with `cd apps/docs && pnpm dev`