### PR TITLE
Review and update ADK-TS observability documentation

### DIFF
--- a/apps/docs/content/docs/framework/observability/getting-started.mdx
+++ b/apps/docs/content/docs/framework/observability/getting-started.mdx
@@ -134,14 +134,23 @@ await telemetryService.initialize({
 });
 
 const sessionId = "session-abc";
+const { runner } = await AgentBuilder.create("my-agent")
+  .withModel("gemini-2.5-flash")
+  .build();
 
-await AgentBuilder.withModel("gemini-2.5-flash").ask("Hello!");
+for await (const _ of runner.runAsync({
+  userId: "user-1",
+  sessionId,
+  newMessage: { role: "user", parts: [{ text: "Hello!" }] },
+})) {
+  // consume events
+}
 
 // Retrieve all spans collected so far
 const allSpans = telemetryService.getTraces();
 console.log(`Captured ${allSpans.length} spans`);
 
-// Or retrieve only spans for a specific session
+// Or retrieve only spans tagged with a specific session ID
 const sessionSpans = telemetryService.getTracesForSession(sessionId);
 console.log(`Session spans: ${sessionSpans.length}`);
 ```

--- a/apps/docs/content/docs/framework/observability/getting-started.mdx
+++ b/apps/docs/content/docs/framework/observability/getting-started.mdx
@@ -1,217 +1,183 @@
 ---
 title: Getting Started
-description: Initialize telemetry and start collecting traces and metrics for your AI agents
+description: Initialize the ADK-TS telemetry service and start collecting traces and metrics
 ---
 
 import { Cards, Card } from "fumadocs-ui/components/card";
 import { Callout } from "fumadocs-ui/components/callout";
 import { Tabs, Tab } from "fumadocs-ui/components/tabs";
 
-This guide covers initializing the telemetry service and collecting traces and metrics. The patterns shown here work for both local development and production environments.
-
-For production-specific considerations like privacy controls and performance tuning, see the [Production Deployment](/docs/framework/observability/production) guide.
-
-## Prerequisites
-
-Telemetry dependencies are included in `@iqai/adk`—no additional packages required.
+Call `telemetryService.initialize()` once, before any agent operations, and ADK-TS starts emitting OpenTelemetry spans and metrics for every agent run, LLM call, and tool execution automatically.
 
 ## Basic Initialization
 
-Initialize the telemetry service before any agent operations:
+The minimal setup requires an `appName` to identify your service in the trace backend. An `otlpEndpoint` is needed to export data anywhere; without it, initialization still succeeds but no data leaves the process.
 
-<Tabs items={['Basic', 'With Options', 'Environment Variables']}>
-  <Tab value="Basic">
+```typescript
+import { telemetryService, AgentBuilder } from "@iqai/adk";
+
+await telemetryService.initialize({
+  appName: "my-agent-app",
+  otlpEndpoint: "http://localhost:4318/v1/traces",
+});
+
+const response = await AgentBuilder.withModel("gemini-2.5-flash").ask("Hello!");
+console.log(response);
+
+await telemetryService.shutdown(5000);
+```
+
+<Callout type="warn" title="Initialize before agents">
+  Always call `initialize()` before creating or running any agent. Spans created
+  before initialization are not captured.
+</Callout>
+
+## Configuration Options
+
+<Tabs items={['Full options', 'Environment variables']}>
+  <Tab value="Full options">
     ```typescript
-    import { telemetryService } from '@iqai/adk';
+    import { telemetryService } from "@iqai/adk";
 
     await telemetryService.initialize({
-      appName: 'my-agent-app',
-      otlpEndpoint: 'http://localhost:4318/v1/traces',
-      appVersion: '1.0.0',
-      enableMetrics: true,
-      enableTracing: true,
-    });
-    ```
+      // Service identification
+      appName: "my-agent-app",
+      appVersion: "1.0.0",
+      environment: "development",
 
-  </Tab>
-
-  <Tab value="With Options">
-    ```typescript
-    import { telemetryService } from '@iqai/adk';
-
-    await telemetryService.initialize({
-      // Required
-      appName: 'my-agent-app',
-      otlpEndpoint: 'http://localhost:4318/v1/traces',
-
-      // Optional
-      appVersion: '1.0.0',
-      environment: 'development',
+      // OTLP export
+      otlpEndpoint: "http://localhost:4318/v1/traces",
+      otlpHeaders: { Authorization: `Bearer ${process.env.OTEL_API_KEY}` },
 
       // Feature flags
       enableTracing: true,
       enableMetrics: true,
-      enableAutoInstrumentation: true, // Enable HTTP/database auto-tracing
+      enableAutoInstrumentation: false,
 
       // Privacy controls
-      captureMessageContent: true, // Set false for production
+      captureMessageContent: true,
 
       // Performance tuning
-      samplingRatio: 1.0, // 1.0 = 100% sampling
-      metricExportIntervalMs: 60000, // 1 minute
+      samplingRatio: 1.0,
+      metricExportIntervalMs: 60000,
 
       // Custom resource attributes
       resourceAttributes: {
-        'deployment.name': 'local',
-        'team': 'platform',
+        "deployment.name": "local",
+        "team": "platform",
+        "revision": 42,
       },
+
+      // Enable in-memory exporter for testing/debugging
+      debug: false,
     });
     ```
 
   </Tab>
-
-  <Tab value="Environment Variables">
-    ```typescript
-    import { telemetryService } from '@iqai/adk';
-
-    // The telemetry system respects standard OpenTelemetry environment variables
-    // OTEL_SERVICE_NAME, OTEL_RESOURCE_ATTRIBUTES, NODE_ENV, etc.
-
-    await telemetryService.initialize({
-      appName: process.env.OTEL_SERVICE_NAME || 'my-agent-app',
-      otlpEndpoint: process.env.OTEL_EXPORTER_OTLP_ENDPOINT || 'http://localhost:4318/v1/traces',
-      environment: process.env.NODE_ENV || 'development',
-    });
-    ```
+  <Tab value="Environment variables">
+    Standard OpenTelemetry environment variables are respected alongside the configuration object. If both are set, the configuration object takes precedence.
 
     ```bash
-    # Set environment variables (shell session)
     export OTEL_SERVICE_NAME=my-agent-app
+    export OTEL_EXPORTER_OTLP_ENDPOINT=http://localhost:4318/v1/traces
     export OTEL_RESOURCE_ATTRIBUTES=deployment.environment=development,team=platform
-    export NODE_ENV=development
     export ADK_CAPTURE_MESSAGE_CONTENT=true
+    export NODE_ENV=development
     ```
 
-    <Callout type="tip" title="Using .env Files">
-      For local development, you can also set these variables in a `.env` file in your project root. ADK-TS automatically loads `.env` files using `dotenv`.
-    </Callout>
+    ```typescript
+    import { telemetryService } from "@iqai/adk";
+
+    await telemetryService.initialize({
+      appName: process.env.OTEL_SERVICE_NAME || "my-agent-app",
+      otlpEndpoint: process.env.OTEL_EXPORTER_OTLP_ENDPOINT || "http://localhost:4318/v1/traces",
+      environment: process.env.NODE_ENV || "development",
+    });
+    ```
 
   </Tab>
 </Tabs>
 
-<Callout type="warn" title="Initialize Early">
-  Always initialize telemetry before any agent operations to ensure all traces
-  and metrics are captured.
-</Callout>
-
 ## Configuration Reference
 
-### Required Options
+| Option                      | Type                                          | Default                       | Description                                                |
+| --------------------------- | --------------------------------------------- | ----------------------------- | ---------------------------------------------------------- |
+| `appName`                   | `string`                                      | —                             | **Required.** Service name shown in trace backends         |
+| `otlpEndpoint`              | `string`                                      | —                             | OTLP HTTP endpoint, e.g. `http://localhost:4318/v1/traces` |
+| `otlpHeaders`               | `Record<string, string>`                      | —                             | Auth headers sent with every OTLP request                  |
+| `appVersion`                | `string`                                      | `"unknown"`                   | Application version                                        |
+| `environment`               | `string`                                      | Auto-detected from `NODE_ENV` | Deployment environment                                     |
+| `enableTracing`             | `boolean`                                     | `true`                        | Enable distributed tracing                                 |
+| `enableMetrics`             | `boolean`                                     | `true`                        | Enable metrics collection                                  |
+| `enableAutoInstrumentation` | `boolean`                                     | `false`                       | Trace outbound HTTP and database calls automatically       |
+| `captureMessageContent`     | `boolean`                                     | `true`                        | Capture LLM prompts, completions, and tool arguments       |
+| `samplingRatio`             | `number`                                      | `1.0`                         | Fraction of traces to sample (0.0–1.0)                     |
+| `metricExportIntervalMs`    | `number`                                      | `60000`                       | How often metrics are exported, in milliseconds            |
+| `resourceAttributes`        | `Record<string, string \| number \| boolean>` | —                             | Extra attributes attached to all spans and metrics         |
+| `debug`                     | `boolean`                                     | `false`                       | Activate in-memory exporter for local inspection           |
 
-| Option         | Type     | Description                                                      |
-| -------------- | -------- | ---------------------------------------------------------------- |
-| `appName`      | `string` | Service name for identification in traces                        |
-| `otlpEndpoint` | `string` | OTLP HTTP endpoint URL (e.g., `http://localhost:4318/v1/traces`) |
-
-### Optional Options
-
-| Option                      | Type                     | Default       | Description                                               |
-| --------------------------- | ------------------------ | ------------- | --------------------------------------------------------- |
-| `appVersion`                | `string`                 | `"unknown"`   | Application version                                       |
-| `environment`               | `string`                 | Auto-detected | Deployment environment (development, staging, production) |
-| `enableTracing`             | `boolean`                | `true`        | Enable distributed tracing                                |
-| `enableMetrics`             | `boolean`                | `true`        | Enable metrics collection                                 |
-| `enableAutoInstrumentation` | `boolean`                | `false`       | Enable automatic HTTP/database tracing                    |
-| `captureMessageContent`     | `boolean`                | `true`        | Capture LLM prompts and completions                       |
-| `samplingRatio`             | `number`                 | `1.0`         | Trace sampling ratio (0.0-1.0)                            |
-| `metricExportIntervalMs`    | `number`                 | `60000`       | Metrics export interval in milliseconds                   |
-| `otlpHeaders`               | `Record<string, string>` | —             | Custom headers for OTLP requests                          |
-| `resourceAttributes`        | `Record<string, string>` | —             | Custom resource attributes                                |
-| `debug`                     | `boolean`                | `false`       | Enable in-memory exporter for debugging                   |
-
-<Callout type="warn" title="Privacy in Production">
-  Set `captureMessageContent: false` in production to avoid capturing sensitive
-  user data in traces.
+<Callout type="warn" title="Privacy in production">
+  Set `captureMessageContent: false` in production to prevent LLM prompts and
+  tool arguments from appearing in your trace backend.
 </Callout>
 
-## Local Development Setup
+## Debug Mode and In-Memory Traces
 
-### Running with Jaeger
+When `debug: true`, ADK-TS additionally routes all spans to an in-memory exporter. You can read them back without a running backend — useful for unit tests or quick local inspection.
 
-Jaeger is a popular open-source distributed tracing system. Use it for local development:
+```typescript
+import { telemetryService, AgentBuilder } from "@iqai/adk";
 
-```bash
-# Start Jaeger all-in-one (includes OTLP receiver)
-docker run -d \
-  --name jaeger \
-  -p 4318:4318 \
-  -p 16686:16686 \
-  jaegertracing/all-in-one:latest
+await telemetryService.initialize({
+  appName: "my-agent-app",
+  debug: true,
+});
+
+const sessionId = "session-abc";
+
+await AgentBuilder.withModel("gemini-2.5-flash").ask("Hello!");
+
+// Retrieve all spans collected so far
+const allSpans = telemetryService.getTraces();
+console.log(`Captured ${allSpans.length} spans`);
+
+// Or retrieve only spans for a specific session
+const sessionSpans = telemetryService.getTracesForSession(sessionId);
+console.log(`Session spans: ${sessionSpans.length}`);
 ```
 
-Your ADK-TS app will send traces to `http://localhost:4318/v1/traces`, and you can view them at `http://localhost:16686`.
+`getTraces()` returns `ReadableSpan[]` from `@opentelemetry/sdk-trace-base`. Each span exposes `name`, `attributes`, `startTime`, `endTime`, and `status`.
 
-### Running with OpenTelemetry Collector
+## Graceful Shutdown
 
-For more advanced setups that need to route telemetry to multiple backends or apply processing, use the OpenTelemetry Collector:
+Always call `shutdown()` before your process exits to flush any pending spans and metrics. Pass a timeout in milliseconds; if the flush takes longer than the timeout, the method throws.
 
-**1. Create collector configuration** (`otel-collector-config.yaml`):
+```typescript
+import { telemetryService } from "@iqai/adk";
 
-```yaml
-receivers:
-  otlp:
-    protocols:
-      http:
-        endpoint: 0.0.0.0:4318
+process.on("SIGTERM", async () => {
+  await telemetryService.shutdown(5000);
+  process.exit(0);
+});
 
-exporters:
-  logging:
-    loglevel: debug
-  otlp/jaeger:
-    endpoint: http://localhost:4317
-    tls:
-      insecure: true
-
-service:
-  pipelines:
-    traces:
-      receivers: [otlp]
-      exporters: [logging, otlp/jaeger]
-    metrics:
-      receivers: [otlp]
-      exporters: [logging]
+process.on("SIGINT", async () => {
+  await telemetryService.shutdown(5000);
+  process.exit(0);
+});
 ```
 
-**2. Run the collector:**
+To flush without shutting down — for example between test cases — use `flush()`:
 
-```bash
-docker run -d \
-  -v $(pwd)/otel-collector-config.yaml:/etc/otel-collector-config.yaml \
-  -p 4318:4318 \
-  otel/opentelemetry-collector:latest \
-  --config=/etc/otel-collector-config.yaml
+```typescript
+await telemetryService.flush(5000);
 ```
-
-<Callout type="info" title="When to Use the Collector">
-  
-For simple setups, sending directly to Jaeger is sufficient. Use the
-OpenTelemetry Collector when you need to:
-
-- Route telemetry to multiple backends
-- Apply processing, filtering, or sampling
-- Transform or enrich telemetry data
-
-</Callout>
 
 ## Complete Example
-
-Here's a complete example that initializes telemetry and runs an agent:
 
 ```typescript
 import { telemetryService, AgentBuilder } from "@iqai/adk";
 
 async function main() {
-  // Initialize telemetry first
   await telemetryService.initialize({
     appName: "example-agent",
     appVersion: "1.0.0",
@@ -220,13 +186,6 @@ async function main() {
     enableTracing: true,
   });
 
-  // Build and run agent
-  const response = await AgentBuilder.withModel("gemini-2.5-flash").ask(
-    "What is the capital of France?",
-  );
-  console.log(response);
-
-  // Graceful shutdown
   process.on("SIGTERM", async () => {
     await telemetryService.shutdown(5000);
     process.exit(0);
@@ -236,53 +195,37 @@ async function main() {
     await telemetryService.shutdown(5000);
     process.exit(0);
   });
+
+  const response = await AgentBuilder.withModel("gemini-2.5-flash").ask(
+    "What is the capital of France?",
+  );
+  console.log(response);
 }
 
 main().catch(console.error);
 ```
 
-## Viewing Traces
-
-<Callout type="info" title="Prerequisites">
-  Make sure Jaeger is running before viewing traces. If you haven't set it up
-  yet, see the "Running with Jaeger" section above for setup instructions.
-</Callout>
-
-Once your application is running and sending traces:
-
-1. **Open Jaeger UI**: Navigate to `http://localhost:16686`
-2. **Select Service**: Choose your service name (e.g., `example-agent`)
-3. **Find Traces**: Click "Find Traces" to see all traces
-4. **Explore**: Click on any trace to see the detailed execution flow
-
-You'll see:
-
-- Agent invocation spans
-- Tool execution spans
-- LLM call spans with token usage
-- Auto-instrumented HTTP calls
-
-## Related Topics
+## Next Steps
 
 <Cards>
   <Card
     title="🔍 Distributed Tracing"
-    description="Understand what gets traced and create custom spans"
+    description="What gets traced automatically and how to add custom spans"
     href="/docs/framework/observability/tracing"
   />
   <Card
     title="📊 Metrics"
-    description="Monitor agent performance with counters and histograms"
+    description="Available metrics and how to record custom measurements"
     href="/docs/framework/observability/metrics"
   />
   <Card
     title="🔌 Platform Integrations"
-    description="Connect to Jaeger, Grafana, Datadog, and other backends"
+    description="Set up Jaeger, Grafana, Datadog, and other backends"
     href="/docs/framework/observability/integrations"
   />
   <Card
-    title="🔒 Production Deployment"
-    description="Privacy controls, performance tuning, and best practices"
+    title="🔒 Production"
+    description="Privacy controls, sampling ratios, and production best practices"
     href="/docs/framework/observability/production"
   />
 </Cards>

--- a/apps/docs/content/docs/framework/observability/index.mdx
+++ b/apps/docs/content/docs/framework/observability/index.mdx
@@ -5,40 +5,34 @@ description: Monitor and debug AI agents with OpenTelemetry-based distributed tr
 
 import { Cards, Card } from "fumadocs-ui/components/card";
 import { Callout } from "fumadocs-ui/components/callout";
+import { Mermaid } from "@/components/mdx/mermaid";
 
-ADK-TS provides built-in observability through OpenTelemetry integration. Monitor your agents' performance, trace execution flows, collect metrics, and gain insights into LLM interactions, tool usage, and agent behavior.
+ADK-TS has built-in OpenTelemetry support. Every agent run, tool call, and LLM request automatically creates spans and records metrics — no manual instrumentation required. The data travels via OTLP to any compatible backend: Jaeger, Grafana, Datadog, New Relic, Honeycomb, or any OTLP endpoint.
 
-<Callout type="info" title="Built-in Support">
-  All telemetry dependencies are included in `@iqai/adk`. No additional packages
-  required.
-</Callout>
+## How It Works
 
-## What You'll Learn
+<Mermaid
+  chart={`
+flowchart LR
+    A[AgentBuilder] --> B[telemetryService.initialize]
+    B --> C[Agent runs]
+    C --> D[agent_run span]
+    D --> E[llm_generate span]
+    D --> F[execute_tool span]
+    E --> G[OTLP Export]
+    F --> G
+    G --> H[(Traces backend\nJaeger / Grafana / Datadog)]
+    G --> I[(Metrics backend\nPrometheus / Datadog)]
+`}
+/>
 
-This section covers everything you need to know about observability in ADK-TS:
+Initialize once before your first agent call. All subsequent agent, tool, and LLM operations emit spans and metrics automatically.
 
-- **Setting up telemetry** - Initialize and configure the telemetry service
-- **Distributed tracing** - Track agent invocations, tool executions, and LLM calls
-- **Metrics collection** - Monitor performance with counters and histograms
-- **Platform integrations** - Connect to Jaeger, Grafana, Datadog, and more
-- **Production deployment** - Privacy controls, performance tuning, and best practices
-
-## Key Features
-
-| Feature                  | Description                                                                                |
-| ------------------------ | ------------------------------------------------------------------------------------------ |
-| **Distributed Tracing**  | Track agent invocations, tool executions, and LLM calls across your system                 |
-| **Metrics Collection**   | Monitor performance with counters, histograms, and token usage tracking                    |
-| **Auto-Instrumentation** | Optional automatic tracing of HTTP calls and database queries                              |
-| **Privacy Controls**     | Configurable content capture for production environments                                   |
-| **Platform Integration** | Works with Jaeger, Grafana, Datadog, New Relic, Honeycomb, and any OTLP-compatible backend |
-
-## Quick Example
+## Quick Start
 
 ```typescript
 import { telemetryService, AgentBuilder } from "@iqai/adk";
 
-// Initialize telemetry before any agent operations
 await telemetryService.initialize({
   appName: "my-agent-app",
   otlpEndpoint: "http://localhost:4318/v1/traces",
@@ -47,20 +41,22 @@ await telemetryService.initialize({
   enableTracing: true,
 });
 
-// Your agents automatically send traces and metrics
 const response = await AgentBuilder.withModel("gemini-2.5-flash").ask("Hello!");
 console.log(response);
 
-// Shutdown gracefully to flush pending telemetry
 await telemetryService.shutdown(5000);
 ```
 
-## Related Topics
+<Callout type="info" title="No extra packages">
+  All telemetry dependencies ship with `@iqai/adk`. Nothing extra to install.
+</Callout>
+
+## Next Steps
 
 <Cards>
   <Card
     title="🚀 Getting Started"
-    description="Initialize and configure telemetry for local development"
+    description="Initialize and configure telemetry with all available options"
     href="/docs/framework/observability/getting-started"
   />
   <Card
@@ -70,17 +66,17 @@ await telemetryService.shutdown(5000);
   />
   <Card
     title="📊 Metrics"
-    description="Monitor agent performance with counters and histograms"
+    description="Monitor performance with counters, histograms, and token tracking"
     href="/docs/framework/observability/metrics"
   />
   <Card
     title="🔌 Platform Integrations"
-    description="Connect to Jaeger, Grafana, Datadog, and other backends"
+    description="Connect to Jaeger, Grafana, Datadog, and other OTLP backends"
     href="/docs/framework/observability/integrations"
   />
   <Card
-    title="🔒 Production Deployment"
-    description="Privacy controls, performance tuning, and best practices"
+    title="🔒 Production"
+    description="Privacy controls, sampling, and best practices for production"
     href="/docs/framework/observability/production"
   />
 </Cards>

--- a/apps/docs/content/docs/framework/observability/integrations.mdx
+++ b/apps/docs/content/docs/framework/observability/integrations.mdx
@@ -1,26 +1,27 @@
 ---
 title: Platform Integrations
-description: Connect ADK-TS to Jaeger, Grafana, Datadog, New Relic, Honeycomb, and other OTLP backends
+description: Connect ADK-TS to Jaeger, Grafana, Datadog, New Relic, Honeycomb, and any OTLP-compatible backend
 ---
 
 import { Cards, Card } from "fumadocs-ui/components/card";
 import { Callout } from "fumadocs-ui/components/callout";
 import { Tabs, Tab } from "fumadocs-ui/components/tabs";
 
-ADK-TS uses the OpenTelemetry Protocol (OTLP) for telemetry export, making it compatible with any observability platform that supports OTLP.
+ADK-TS exports telemetry via OTLP HTTP, making it compatible with any observability platform that accepts OTLP. Point `otlpEndpoint` at your backend and the framework handles the rest.
 
-## OTLP Compatibility
-
-All integrations use the standard OTLP HTTP endpoint. ADK-TS sends traces and metrics via OTLP, which is supported by most modern observability platforms.
+<Callout type="info" title="Endpoint format">
+  The `otlpEndpoint` value is used as-is for traces. For metrics, ADK-TS derives
+  the metrics URL by replacing `/v1/traces` with `/v1/metrics` in the same
+  string. Always include the full path in your endpoint.
+</Callout>
 
 ## Jaeger
 
-Jaeger is an open-source distributed tracing system, perfect for local development and production deployments.
+Jaeger is an open-source distributed tracing system. It only supports traces, not metrics — use it for local development or as a dedicated tracing backend.
 
-### Docker Setup
+**Start Jaeger locally with Docker:**
 
 ```bash
-# Start Jaeger all-in-one
 docker run -d \
   --name jaeger \
   -p 4318:4318 \
@@ -28,63 +29,52 @@ docker run -d \
   jaegertracing/all-in-one:latest
 ```
 
-### Configuration
+Port `4318` accepts OTLP HTTP and port `16686` serves the Jaeger UI.
 
-<Tabs items={['Local Development', 'Production']}>
-  <Tab value="Local Development">
-```typescript
-import { telemetryService } from '@iqai/adk';
+<Tabs items={['Local development', 'Production']}>
+  <Tab value="Local development">
+    ```typescript
+    import { telemetryService } from "@iqai/adk";
 
-await telemetryService.initialize({
-appName: 'my-agent-app',
-otlpEndpoint: 'http://localhost:4318/v1/traces',
-enableMetrics: true,
-enableTracing: true,
-});
+    await telemetryService.initialize({
+      appName: "my-agent-app",
+      otlpEndpoint: "http://localhost:4318/v1/traces",
+      enableTracing: true,
+      enableMetrics: false, // Jaeger doesn't support metrics
+    });
+    ```
 
-````
   </Tab>
   <Tab value="Production">
-```typescript
-import { telemetryService } from '@iqai/adk';
+    ```typescript
+    import { telemetryService } from "@iqai/adk";
 
-await telemetryService.initialize({
-  appName: 'my-agent-app',
-  otlpEndpoint: 'https://jaeger.your-domain.com:4318/v1/traces',
-  enableMetrics: true,
-  enableTracing: true,
-  environment: 'production',
-});
-````
+    await telemetryService.initialize({
+      appName: "my-agent-app",
+      otlpEndpoint: "https://jaeger.your-domain.com:4318/v1/traces",
+      enableTracing: true,
+      enableMetrics: false,
+      environment: "production",
+    });
+    ```
 
   </Tab>
 </Tabs>
 
-<Callout type="info" title="Production Deployment">
-  For production, deploy Jaeger using Docker Compose or Kubernetes with proper
-  persistence and scaling. Replace `localhost` with your Jaeger instance URL.
-  See the [Production Deployment](/docs/framework/observability/production)
-  guide for more details.
-</Callout>
-
-### Viewing Traces
-
-- **Local**: Open `http://localhost:16686` in your browser
-- **Production**: Access your Jaeger UI at your configured domain
+Open `http://localhost:16686`, select your service name, and click **Find Traces** to view spans.
 
 ## Grafana + Tempo
 
-Grafana with Tempo provides a complete observability stack with traces, metrics, and logs.
+Grafana with Tempo provides traces and metrics together. The following Docker Compose setup runs everything locally.
 
-### Docker Compose Setup
+**`docker-compose.yml`:**
 
 ```yaml
-# docker-compose.yml
 services:
   tempo:
     image: grafana/tempo:latest
     ports:
-      - "4318:4318" # OTLP HTTP
+      - "4318:4318"
     volumes:
       - ./tempo.yaml:/etc/tempo.yaml
     command: ["-config.file=/etc/tempo.yaml"]
@@ -99,12 +89,9 @@ services:
       - tempo
 ```
 
-### Tempo Configuration
-
-Create a `tempo.yaml` file in the same directory as your `docker-compose.yml`:
+**`tempo.yaml`:**
 
 ```yaml
-# tempo.yaml
 server:
   http_listen_port: 3200
 
@@ -122,15 +109,9 @@ storage:
       path: /tmp/tempo/traces
 ```
 
-This minimal configuration:
-
-- Sets up the Tempo HTTP server on port 3200
-- Configures OTLP receiver on port 4318 (matching the docker-compose port mapping)
-- Uses local storage for traces (suitable for development)
-
-### Configuration
-
 ```typescript
+import { telemetryService } from "@iqai/adk";
+
 await telemetryService.initialize({
   appName: "my-agent-app",
   otlpEndpoint: "http://localhost:4318/v1/traces",
@@ -139,71 +120,50 @@ await telemetryService.initialize({
 });
 ```
 
-### Viewing Traces
-
-1. Open `http://localhost:3000`
-2. Configure Tempo as a data source
-3. Create dashboards for traces and metrics
+Open Grafana at `http://localhost:3000`, add Tempo as a data source pointing to `http://tempo:3200`, then create dashboards for traces and metrics.
 
 ## Datadog
 
-Datadog provides comprehensive APM and monitoring capabilities.
-
-### Configuration
+Datadog's OTLP ingestion accepts both traces and metrics. The endpoint domain varies by Datadog site.
 
 ```typescript
+import { telemetryService } from "@iqai/adk";
+
 await telemetryService.initialize({
   appName: "my-agent-app",
-  otlpEndpoint: "https://otlp.datadoghq.com:4318",
+  otlpEndpoint: "https://otlp.datadoghq.com:4318/v1/traces",
   otlpHeaders: {
     "DD-API-KEY": process.env.DD_API_KEY,
   },
   enableMetrics: true,
   enableTracing: true,
+  environment: "production",
 });
 ```
 
-<Callout type="info">
-  The ADK-TS telemetry service automatically appends `/v1/traces` and
-  `/v1/metrics` to the OTLP endpoint, so you should only specify the base URL
-  without the path suffix.
-</Callout>
+**Endpoint by Datadog site:**
 
-### Environment Variables
+| Site          | Endpoint                                        |
+| ------------- | ----------------------------------------------- |
+| US1 (default) | `https://otlp.datadoghq.com:4318/v1/traces`     |
+| EU            | `https://otlp.datadoghq.eu:4318/v1/traces`      |
+| US3           | `https://otlp.us3.datadoghq.com:4318/v1/traces` |
+| US5           | `https://otlp.us5.datadoghq.com:4318/v1/traces` |
+| AP1           | `https://otlp.ap1.datadoghq.com:4318/v1/traces` |
 
-Create a `.env` file in your project root:
+Store your API key in an environment variable and never commit it to source control:
 
 ```bash
 DD_API_KEY=your-datadog-api-key
-DD_SITE=datadoghq.com  # or datadoghq.eu for EU
 ```
-
-### Datadog Site Configuration
-
-The OTLP endpoint domain varies based on your Datadog site:
-
-- **US**: `https://otlp.datadoghq.com:4318` (default)
-- **EU**: `https://otlp.datadoghq.eu:4318`
-- **US3**: `https://otlp.us3.datadoghq.com:4318`
-- **US5**: `https://otlp.us5.datadoghq.com:4318`
-- **AP1**: `https://otlp.ap1.datadoghq.com:4318`
-
-Configure the endpoint based on your Datadog site setting.
-
-### Features
-
-- Automatic service mapping
-- APM traces with flame graphs
-- Custom metrics and dashboards
-- Alerting and monitoring
 
 ## New Relic
 
-New Relic offers full-stack observability with APM, infrastructure monitoring, and logs.
-
-### Configuration
+New Relic accepts OTLP directly via its ingest endpoint:
 
 ```typescript
+import { telemetryService } from "@iqai/adk";
+
 await telemetryService.initialize({
   appName: "my-agent-app",
   otlpEndpoint: "https://otlp.nr-data.net:4318/v1/traces",
@@ -215,153 +175,129 @@ await telemetryService.initialize({
 });
 ```
 
-### Environment Variables
-
-Create a `.env` file in your project root:
-
 ```bash
 NEW_RELIC_LICENSE_KEY=your-license-key
 ```
 
-### Features
-
-- Distributed tracing
-- Application performance monitoring
-- Custom metrics and dashboards
-- Alert policies
-
 ## Honeycomb
 
-Honeycomb provides high-cardinality observability with powerful query capabilities.
-
-### Configuration
+Honeycomb targets a specific dataset per request. Pass your API key and dataset name as headers:
 
 ```typescript
+import { telemetryService } from "@iqai/adk";
+
 await telemetryService.initialize({
   appName: "my-agent-app",
   otlpEndpoint: "https://api.honeycomb.io/v1/traces",
   otlpHeaders: {
     "x-honeycomb-team": process.env.HONEYCOMB_API_KEY,
-    "x-honeycomb-dataset": "my-dataset",
+    "x-honeycomb-dataset": "my-agents",
   },
   enableMetrics: true,
   enableTracing: true,
 });
 ```
 
-### Environment Variables
-
-Create a `.env` file in your project root:
-
 ```bash
 HONEYCOMB_API_KEY=your-api-key
-HONEYCOMB_DATASET=my-dataset
 ```
-
-### Features
-
-- High-cardinality data exploration
-- Powerful query language
-- BubbleUp for anomaly detection
-- Custom dashboards
 
 ## OpenTelemetry Collector
 
-For advanced setups, use the OpenTelemetry Collector to route telemetry to multiple backends.
+The Collector is a middleware process that receives OTLP from ADK-TS and forwards it to one or more backends. Use it when you need to route telemetry to multiple destinations, apply attribute processing, or run a sampling processor.
 
-### Collector Configuration
+**`otel-collector-config.yaml`:**
 
 ```yaml
-# otel-collector-config.yaml
 receivers:
   otlp:
     protocols:
       http:
         endpoint: 0.0.0.0:4318
 
-exporters:
-  logging:
-    loglevel: debug
-  jaeger:
-    endpoint: jaeger:14250
-    tls:
-      insecure: true
-  otlp/datadog:
-    endpoint: https://otlp.datadoghq.com:4318
-    headers:
-      DD-API-KEY: ${DD_API_KEY}
-
 processors:
   batch:
     timeout: 10s
     send_batch_size: 1024
+
+exporters:
+  otlphttp/jaeger:
+    endpoint: http://jaeger:4318
+  otlphttp/datadog:
+    endpoint: https://otlp.datadoghq.com:4318
+    headers:
+      DD-API-KEY: ${env:DD_API_KEY}
 
 service:
   pipelines:
     traces:
       receivers: [otlp]
       processors: [batch]
-      exporters: [logging, jaeger, otlp/datadog]
+      exporters: [otlphttp/jaeger, otlphttp/datadog]
     metrics:
       receivers: [otlp]
       processors: [batch]
-      exporters: [logging]
+      exporters: [otlphttp/datadog]
 ```
 
-### Running the Collector
+**Start the Collector:**
 
 ```bash
 docker run -d \
   -v $(pwd)/otel-collector-config.yaml:/etc/otel-collector-config.yaml \
   -p 4318:4318 \
   -e DD_API_KEY=your-key \
-  otel/opentelemetry-collector:latest \
+  otel/opentelemetry-collector-contrib:latest \
   --config=/etc/otel-collector-config.yaml
 ```
 
-### Configuration
-
 ```typescript
+import { telemetryService } from "@iqai/adk";
+
 await telemetryService.initialize({
   appName: "my-agent-app",
-  otlpEndpoint: "http://localhost:4318/v1/traces", // Send to collector
+  otlpEndpoint: "http://localhost:4318/v1/traces",
   enableMetrics: true,
   enableTracing: true,
 });
 ```
 
-## Custom Backends
+ADK-TS sends to the Collector, which fans out to all configured exporters.
 
-Any backend that supports OTLP HTTP can be used:
+## Custom OTLP Backends
+
+Any backend that accepts OTLP HTTP works without additional configuration:
 
 ```typescript
+import { telemetryService } from "@iqai/adk";
+
 await telemetryService.initialize({
   appName: "my-agent-app",
-  otlpEndpoint: "https://your-custom-backend.com/v1/traces",
+  otlpEndpoint: "https://telemetry.your-company.com/v1/traces",
   otlpHeaders: {
-    Authorization: `Bearer ${process.env.API_TOKEN}`,
+    Authorization: `Bearer ${process.env.TELEMETRY_TOKEN}`,
   },
   enableMetrics: true,
   enableTracing: true,
 });
 ```
 
-## Related Topics
+## Next Steps
 
 <Cards>
   <Card
-    title="🔒 Production Deployment"
-    description="Privacy controls, performance tuning, and best practices"
+    title="🔒 Production"
+    description="Privacy controls, sampling, and performance tuning"
     href="/docs/framework/observability/production"
   />
   <Card
     title="🔍 Distributed Tracing"
-    description="Understand what gets traced and create custom spans"
+    description="What gets traced and how to add custom spans"
     href="/docs/framework/observability/tracing"
   />
   <Card
     title="📊 Metrics"
-    description="Monitor agent performance with counters and histograms"
+    description="Available metrics and how to query them"
     href="/docs/framework/observability/metrics"
   />
 </Cards>

--- a/apps/docs/content/docs/framework/observability/metrics.mdx
+++ b/apps/docs/content/docs/framework/observability/metrics.mdx
@@ -1,181 +1,171 @@
 ---
 title: Metrics
-description: Monitor agent performance with counters, histograms, and token usage tracking
+description: Counters and histograms ADK-TS records automatically, plus how to record your own measurements
 ---
 
 import { Cards, Card } from "fumadocs-ui/components/card";
 import { Callout } from "fumadocs-ui/components/callout";
 
-ADK-TS collects metrics for agent performance, tool usage, LLM interactions, and error rates. All metrics follow OpenTelemetry standards and are exported via OTLP.
+ADK-TS records metrics for every agent invocation, tool execution, and LLM call. Metrics are exported via OTLP on a configurable interval and follow OpenTelemetry standards, so they work with Prometheus, Grafana, Datadog, and any other OTLP-compatible metrics backend.
 
-## Available Metrics
+<Callout type="info" title="Jaeger only supports traces">
+  Jaeger does not ingest metrics. Use Grafana with Tempo or a full OTLP backend
+  like Datadog for metrics visualization.
+</Callout>
 
-The telemetry system automatically collects metrics for all agent operations. Metrics are exported at regular intervals (configurable via `metricExportIntervalMs`). Metrics can be monitored using counters and histograms.
+## Automatic Metrics
 
 ### Counters
 
-Counters track the total number of operations:
+Counters increment once per operation and reset on process restart:
 
-| Metric                  | Description             | Labels                                             |
-| ----------------------- | ----------------------- | -------------------------------------------------- |
-| `adk.agent.invocations` | Total agent invocations | `agent.name`, `environment`, `status`              |
-| `adk.tool.executions`   | Total tool executions   | `tool.name`, `agent.name`, `environment`, `status` |
-| `adk.llm.calls`         | Total LLM calls         | `model`, `agent.name`, `environment`, `status`     |
-| `adk.errors`            | Total errors            | `error_type`, `context`                            |
+| Metric                  | Labels                                             | Description             |
+| ----------------------- | -------------------------------------------------- | ----------------------- |
+| `adk.agent.invocations` | `agent.name`, `environment`, `status`              | Total agent invocations |
+| `adk.tool.executions`   | `tool.name`, `agent.name`, `environment`, `status` | Total tool executions   |
+| `adk.llm.calls`         | `model`, `agent.name`, `environment`, `status`     | Total LLM calls         |
+| `adk.errors`            | `error_type`, `context`                            | Total errors            |
 
 ### Histograms
 
-Histograms track distributions of values:
+Histograms record distributions of values, enabling percentile queries:
 
-| Metric                  | Description                | Labels                                             | Unit  |
-| ----------------------- | -------------------------- | -------------------------------------------------- | ----- |
-| `adk.agent.duration`    | Agent execution duration   | `agent.name`, `environment`, `status`              | ms    |
-| `adk.tool.duration`     | Tool execution duration    | `tool.name`, `agent.name`, `environment`, `status` | ms    |
-| `adk.llm.duration`      | LLM call duration          | `model`, `agent.name`, `environment`, `status`     | ms    |
-| `adk.llm.tokens`        | Total tokens per LLM call  | `model`, `agent.name`, `environment`, `status`     | count |
-| `adk.llm.tokens.input`  | Input tokens per LLM call  | `model`, `agent.name`, `environment`, `status`     | count |
-| `adk.llm.tokens.output` | Output tokens per LLM call | `model`, `agent.name`, `environment`, `status`     | count |
+| Metric                  | Unit   | Labels                                             | Description                |
+| ----------------------- | ------ | -------------------------------------------------- | -------------------------- |
+| `adk.agent.duration`    | ms     | `agent.name`, `environment`, `status`              | Agent execution duration   |
+| `adk.tool.duration`     | ms     | `tool.name`, `agent.name`, `environment`, `status` | Tool execution duration    |
+| `adk.llm.duration`      | ms     | `model`, `agent.name`, `environment`, `status`     | LLM call duration          |
+| `adk.llm.tokens`        | tokens | `model`, `agent.name`, `environment`, `status`     | Total tokens per LLM call  |
+| `adk.llm.tokens.input`  | tokens | `model`, `agent.name`, `environment`, `status`     | Input tokens per LLM call  |
+| `adk.llm.tokens.output` | tokens | `model`, `agent.name`, `environment`, `status`     | Output tokens per LLM call |
 
-## Metric Labels
+The `status` label is either `success` or `error`. All metrics also pick up any resource attributes you set via `resourceAttributes` during initialization.
 
-All metrics include labels for filtering and aggregation:
+## Metric Export Interval
 
-- **`agent.name`** - Name of the agent
-- **`tool.name`** - Name of the tool (for tool metrics)
-- **`model`** - LLM model name (for LLM metrics)
-- **`environment`** - Deployment environment
-- **`status`** - Operation status (`success`, `error`)
-- **`error_type`** - Type of error (for error metrics)
-- **`context`** - Error context (for error metrics)
-
-## Metric Dimensions
-
-When recording metrics, you can include additional dimensions:
+Metrics are buffered and exported periodically rather than per-operation. The default interval is 60 seconds. Shorten it for dashboards that need near-real-time data; lengthen it for production to reduce overhead:
 
 ```typescript
-telemetryService.recordAgentInvocation({
-  agentName: "my-agent",
-  environment: "production",
-  status: "success",
-  // Additional dimensions can be added via resource attributes
+await telemetryService.initialize({
+  appName: "my-agent-app",
+  otlpEndpoint: "http://localhost:4318/v1/traces",
+  metricExportIntervalMs: 30000, // export every 30 seconds
 });
 ```
 
-Resource attributes are automatically included as metric labels, allowing you to filter and aggregate by deployment, team, or any custom attribute.
+ADK-TS derives the metrics endpoint from the traces endpoint by replacing `/v1/traces` with `/v1/metrics`. Both point to the same host and port, so a single `otlpEndpoint` value covers both.
 
 ## Recording Custom Metrics
 
-You can manually record metrics for custom operations:
+For operations outside the automatic instrumentation — batch jobs, background workers, or business-level counters — you can record metrics directly:
 
 ```typescript
 import { telemetryService } from "@iqai/adk";
 
-// Record agent invocation
+// Count a successful agent run
 telemetryService.recordAgentInvocation({
-  agentName: "my-agent",
+  agentName: "research-agent",
   environment: "production",
   status: "success",
 });
 
-// Record agent duration
+// Record how long the agent took
 telemetryService.recordAgentDuration(1500, {
-  agentName: "my-agent",
+  agentName: "research-agent",
   environment: "production",
   status: "success",
 });
 
-// Record tool execution
+// Count a tool execution
 telemetryService.recordToolExecution({
   toolName: "search_web",
-  agentName: "my-agent",
+  agentName: "research-agent",
   environment: "production",
   status: "success",
 });
 
-// Record LLM tokens
-telemetryService.recordLlmTokens(150, 75, {
-  model: "gpt-4",
-  agentName: "my-agent",
+// Record tool duration
+telemetryService.recordToolDuration(450, {
+  toolName: "search_web",
+  agentName: "research-agent",
   environment: "production",
   status: "success",
 });
+
+// Count an LLM call
+telemetryService.recordLlmCall({
+  model: "gemini-2.5-flash",
+  agentName: "research-agent",
+  environment: "production",
+  status: "success",
+});
+
+// Record LLM duration
+telemetryService.recordLlmDuration(1200, {
+  model: "gemini-2.5-flash",
+  agentName: "research-agent",
+  environment: "production",
+  status: "success",
+});
+
+// Record token usage (input tokens, output tokens, then dimensions)
+telemetryService.recordLlmTokens(150, 75, {
+  model: "gemini-2.5-flash",
+  agentName: "research-agent",
+  environment: "production",
+  status: "success",
+});
+
+// Record an error
+telemetryService.recordError("tool", "search_web");
 ```
 
-## Metric Export
+The `recordError` method increments `adk.errors` with `error_type` set to `"agent"`, `"tool"`, or `"llm"` and `context` set to the string you pass.
 
-Metrics are automatically exported to your configured OTLP endpoint at regular intervals. The default export interval is 60 seconds (60000ms), but you can configure it:
+## Metric Name Constants
+
+Use the `METRICS` constant when building dashboards or alert queries — it lists all metric names in one place:
 
 ```typescript
-await telemetryService.initialize({
-  appName: "my-app",
-  otlpEndpoint: "http://localhost:4318/v1/traces",
-  metricExportIntervalMs: 30000, // Export every 30 seconds
-});
+import { METRICS } from "@iqai/adk";
+
+METRICS.AGENT_INVOCATIONS; // "adk.agent.invocations"
+METRICS.TOOL_EXECUTIONS; // "adk.tool.executions"
+METRICS.LLM_CALLS; // "adk.llm.calls"
+METRICS.ERRORS; // "adk.errors"
+METRICS.AGENT_DURATION; // "adk.agent.duration"
+METRICS.TOOL_DURATION; // "adk.tool.duration"
+METRICS.LLM_DURATION; // "adk.llm.duration"
+METRICS.LLM_TOKENS; // "adk.llm.tokens"
+METRICS.LLM_INPUT_TOKENS; // "adk.llm.tokens.input"
+METRICS.LLM_OUTPUT_TOKENS; // "adk.llm.tokens.output"
 ```
 
-<Callout type="info" title="Export Interval">
-  Adjust the export interval based on your needs. More frequent exports provide
-  real-time metrics but may increase overhead.
-</Callout>
+## Common Dashboard Queries
 
-## Viewing Metrics
+These PromQL examples work with Grafana backed by Prometheus or any OTLP-to-Prometheus bridge:
 
-ADK-TS sends metrics via OTLP to any compatible observability backend. You'll need to set up an external metrics visualization tool separately. Popular options include Grafana (with Tempo or Prometheus), Datadog, New Relic, and Honeycomb.
+```text
+# Agent invocation rate (per minute)
+rate(adk_agent_invocations_total[5m]) * 60
 
-<Callout type="info" title="No Built-in Viewer">
-  ADK-TS does not include a built-in metrics viewer. You need to set up an
-  external observability platform to view metrics. See the [Platform
-  Integrations](/docs/framework/observability/integrations) guide for setup
-  instructions.
-</Callout>
+# 95th percentile LLM latency
+histogram_quantile(0.95, rate(adk_llm_duration_bucket[5m]))
 
-### Grafana
+# Error rate across all agent operations
+sum(rate(adk_errors_total[5m]))
 
-Grafana is a popular open-source visualization tool that can display metrics from various backends:
-
-1. **Set up Grafana**: See the [Platform Integrations](/docs/framework/observability/integrations#grafana--tempo) guide for Docker setup instructions
-2. **Configure OTLP receiver** in your observability backend
-3. **Create dashboards** with queries for ADK-TS metrics
-4. **Set up alerts** based on metric thresholds
-
-Example Grafana queries:
-
-- `rate(adk_agent_invocations_total[5m])` - Agent invocation rate
-- `histogram_quantile(0.95, adk_llm_duration_bucket)` - 95th percentile LLM latency
-- `sum(rate(adk_errors_total[5m]))` - Error rate
-
-### Prometheus
-
-Prometheus is a metrics database that can be used with Grafana for visualization. If using Prometheus, configure the OpenTelemetry Collector to export metrics in Prometheus format:
-
-```yaml
-# otel-collector-config.yaml
-exporters:
-  prometheus:
-    endpoint: "0.0.0.0:8889"
-
-service:
-  pipelines:
-    metrics:
-      receivers: [otlp]
-      exporters: [prometheus]
+# Token cost breakdown by model
+sum by (model) (rate(adk_llm_tokens_input_bucket[1h]))
+sum by (model) (rate(adk_llm_tokens_output_bucket[1h]))
 ```
 
-## Common Use Cases
-
-| Use Case        | Metrics to Monitor                                              |
-| --------------- | --------------------------------------------------------------- |
-| **Performance** | `adk.agent.duration`, `adk.tool.duration`, `adk.llm.duration`   |
-| **Costs**       | `adk.llm.tokens.input`, `adk.llm.tokens.output`                 |
-| **Reliability** | `adk.errors`, error rates by `error_type`                       |
-| **Usage**       | `adk.agent.invocations`, `adk.tool.executions`, `adk.llm.calls` |
-
-## Related Topics
+## Next Steps
 
 <Cards>
   <Card
     title="🔍 Distributed Tracing"
-    description="Correlate metrics with traces for debugging"
+    description="Correlate metrics with traces to identify bottlenecks"
     href="/docs/framework/observability/tracing"
   />
   <Card
@@ -184,8 +174,8 @@ service:
     href="/docs/framework/observability/integrations"
   />
   <Card
-    title="🔒 Production Deployment"
-    description="Configure optimal metric collection for production"
+    title="🔒 Production"
+    description="Tune export intervals and sampling for production workloads"
     href="/docs/framework/observability/production"
   />
 </Cards>

--- a/apps/docs/content/docs/framework/observability/production.mdx
+++ b/apps/docs/content/docs/framework/observability/production.mdx
@@ -1,48 +1,37 @@
 ---
-title: Production Deployment
-description: Privacy controls, performance tuning, best practices, and troubleshooting for observability
+title: Production
+description: Privacy controls, sampling, performance tuning, and troubleshooting for ADK-TS observability in production
 ---
 
 import { Cards, Card } from "fumadocs-ui/components/card";
 import { Callout } from "fumadocs-ui/components/callout";
 import { Tabs, Tab } from "fumadocs-ui/components/tabs";
 
-This guide covers production-ready configuration for observability in ADK-TS, including privacy controls, performance tuning, best practices, and troubleshooting.
+Running telemetry in production requires three adjustments from a development setup: disable content capture to protect user data, reduce the sampling ratio to limit overhead, and increase the metric export interval to reduce network traffic.
 
 ## Production Configuration
 
-Here's a complete production-ready configuration:
+This is a complete production-ready initialization. Read the sections below for the reasoning behind each setting.
 
 ```typescript
 import { telemetryService } from "@iqai/adk";
 
 await telemetryService.initialize({
-  // Required
   appName: process.env.OTEL_SERVICE_NAME || "my-agent-app",
+  appVersion: process.env.APP_VERSION || "1.0.0",
   otlpEndpoint:
     process.env.OTEL_EXPORTER_OTLP_ENDPOINT ||
     "https://your-backend.com/v1/traces",
-
-  // Environment
-  environment: process.env.NODE_ENV || "production",
-  appVersion: process.env.APP_VERSION || "1.0.0",
-
-  // Authentication
   otlpHeaders: {
     "api-key": process.env.OTEL_API_KEY || "",
   },
-
-  // Feature flags
+  environment: process.env.NODE_ENV || "production",
   enableTracing: true,
   enableMetrics: true,
   enableAutoInstrumentation: false,
-
-  // Privacy and performance
   captureMessageContent: false,
   samplingRatio: 0.1,
   metricExportIntervalMs: 300000,
-
-  // Custom attributes
   resourceAttributes: {
     "deployment.name": process.env.DEPLOYMENT_NAME || "production",
     team: process.env.TEAM_NAME || "platform",
@@ -50,68 +39,23 @@ await telemetryService.initialize({
 });
 ```
 
-## Environment Variables
+**Corresponding environment variables:**
 
 ```bash
-# Service identification
-export OTEL_SERVICE_NAME=my-agent-app
-export APP_VERSION=1.0.0
-
-# Privacy
-export ADK_CAPTURE_MESSAGE_CONTENT=false
-
-# Performance
-export OTEL_SAMPLING_RATIO=0.1
-export METRIC_EXPORT_INTERVAL_MS=300000
-
-# OTLP endpoint
-export OTEL_EXPORTER_OTLP_ENDPOINT=https://your-backend.com/v1/traces
-export OTEL_API_KEY=your-api-key
-
-# Environment
-export NODE_ENV=production
+OTEL_SERVICE_NAME=my-agent-app
+APP_VERSION=1.0.0
+OTEL_EXPORTER_OTLP_ENDPOINT=https://your-backend.com/v1/traces
+OTEL_API_KEY=your-api-key
+ADK_CAPTURE_MESSAGE_CONTENT=false
+NODE_ENV=production
 ```
 
-## Configuration Reference
+## Privacy: Disable Content Capture
 
-| Setting                     | Development | Production        | Description                                        |
-| --------------------------- | ----------- | ----------------- | -------------------------------------------------- |
-| `captureMessageContent`     | `true`      | `false`           | Capture LLM prompts/completions and tool arguments |
-| `samplingRatio`             | `1.0`       | `0.1`–`0.2`       | Percentage of traces to sample (0.0-1.0)           |
-| `metricExportIntervalMs`    | `60000`     | `300000`–`600000` | Metric export interval in milliseconds             |
-| `enableAutoInstrumentation` | `false`     | `false`           | HTTP/database auto-tracing (enable only if needed) |
+When `captureMessageContent` is enabled (the default), ADK-TS writes LLM prompts, completions, and tool arguments into span attributes. In production this almost certainly captures personally identifiable information.
 
-<Callout type="warn" title="Privacy in Production">
-  Always set `captureMessageContent: false` in production to protect user data
-  and comply with privacy regulations.
-</Callout>
-
-## Best Practices
-
-### Initialize Before Agent Operations
-
-Always initialize telemetry before creating or running agents:
-
-```typescript
-// ✅ Correct order
-await telemetryService.initialize({
-  /* config */
-});
-const agent = AgentBuilder.withModel("gemini-2.5-flash").build();
-
-// ❌ Wrong - traces may be missed
-const agent = AgentBuilder.withModel("gemini-2.5-flash").build();
-await telemetryService.initialize({
-  /* config */
-});
-```
-
-### Disable Content Capture
-
-Protect user privacy by disabling content capture in production:
-
-<Tabs items={['Environment Variable', 'Configuration']}>
-  <Tab value="Environment Variable">
+<Tabs items={['Environment variable', 'Configuration']}>
+  <Tab value="Environment variable">
     ```bash
     export ADK_CAPTURE_MESSAGE_CONTENT=false
     ```
@@ -119,33 +63,74 @@ Protect user privacy by disabling content capture in production:
   <Tab value="Configuration">
     ```typescript
     await telemetryService.initialize({
+      appName: "my-agent-app",
+      otlpEndpoint: "https://your-backend.com/v1/traces",
       captureMessageContent: false,
     });
     ```
   </Tab>
 </Tabs>
 
-When disabled, tool arguments, tool responses, LLM prompts, and completions are not recorded. Metadata like model name, token counts, and duration are still captured.
+With content capture disabled, span attributes like `gen_ai.tool.call.arguments`, `gen_ai.input.messages`, and `gen_ai.output.messages` are not set. Metadata — model name, token counts, duration, status — is always captured regardless of this setting.
 
-### Use Environment Variables for Secrets
+<Callout type="warn" title="Default is capture-on">
+  `captureMessageContent` defaults to `true`. You must explicitly disable it in
+  production or all LLM prompts will appear in your trace backend.
+</Callout>
 
-Never hardcode API keys or endpoints:
+## Sampling Ratio
+
+At 100% sampling (`samplingRatio: 1.0`), every agent run produces a trace. For high-traffic services this creates significant storage and ingestion costs. Reduce sampling in production — you still get representative data for debugging while cutting overhead substantially.
 
 ```typescript
-// ✅ Good - use environment variables
-otlpHeaders: {
-  "api-key": process.env.OTEL_API_KEY,
-},
-
-// ❌ Bad - hardcoded secret
-otlpHeaders: {
-  "api-key": "sk-abc123...",
-},
+await telemetryService.initialize({
+  appName: "my-agent-app",
+  otlpEndpoint: "https://your-backend.com/v1/traces",
+  samplingRatio: 0.1, // capture 10% of traces
+});
 ```
 
-### Implement Graceful Shutdown
+Recommended ratios by environment:
 
-Always shutdown telemetry to flush pending data:
+| Environment | Ratio       | Notes                                 |
+| ----------- | ----------- | ------------------------------------- |
+| Development | `1.0`       | Capture everything                    |
+| Staging     | `0.5`       | Half-rate for representative coverage |
+| Production  | `0.1`–`0.2` | Balance visibility with cost          |
+
+## Metric Export Interval
+
+Metrics are buffered and flushed on a timer. The default is 60 seconds; in production, 5–10 minutes is usually sufficient and reduces network overhead:
+
+```typescript
+await telemetryService.initialize({
+  appName: "my-agent-app",
+  otlpEndpoint: "https://your-backend.com/v1/traces",
+  metricExportIntervalMs: 300000, // 5 minutes
+});
+```
+
+## Initialize Before Agents
+
+Spans emitted before `initialize()` completes are not captured. Build your telemetry setup before any agent or runner construction:
+
+```typescript
+// ✅ Correct order
+await telemetryService.initialize({
+  /* config */
+});
+const agent = AgentBuilder.withModel("gemini-2.5-flash").buildLlm();
+
+// ❌ Traces will be missing
+const agent = AgentBuilder.withModel("gemini-2.5-flash").buildLlm();
+await telemetryService.initialize({
+  /* config */
+});
+```
+
+## Graceful Shutdown
+
+`shutdown()` flushes all buffered spans and metrics before the process exits. Without it, any data written after the last export interval is silently dropped.
 
 ```typescript
 process.on("SIGTERM", async () => {
@@ -159,174 +144,56 @@ process.on("SIGINT", async () => {
 });
 ```
 
-The timeout (5000ms) ensures telemetry is flushed even if the backend is slow. Adjust based on your network conditions.
+The timeout (5000 ms) covers the round-trip to your backend. Increase it if you're on a high-latency link or during graceful drain periods. Use `flush()` instead of `shutdown()` if you want to flush without tearing down the provider — for example, between test runs.
 
-### Optimize Sampling for High Traffic
+## Secrets in Environment Variables
 
-Reduce sampling ratio to minimize overhead in high-traffic scenarios:
-
-```typescript
-await telemetryService.initialize({
-  samplingRatio: 0.1, // Sample 10% of traces
-});
-```
-
-**Recommended sampling ratios:**
-
-- Development: `1.0` (100%)
-- Staging: `0.5` (50%)
-- Production: `0.1`–`0.2` (10-20%)
-
-### Adjust Metric Export Interval
-
-Export metrics less frequently in production to reduce overhead:
+Never hardcode API keys:
 
 ```typescript
-await telemetryService.initialize({
-  metricExportIntervalMs: 300000, // Export every 5 minutes
-});
-```
+// ✅ Use environment variables
+otlpHeaders: {
+  "api-key": process.env.OTEL_API_KEY,
+},
 
-**Recommended intervals:**
-
-- Development: `60000` (1 minute)
-- Production: `300000`–`600000` (5-10 minutes)
-
-### Use HTTPS for OTLP Endpoints
-
-Always use HTTPS in production:
-
-```typescript
-// ✅ Good
-otlpEndpoint: "https://your-backend.com/v1/traces",
-
-// ❌ Bad for production
-otlpEndpoint: "http://your-backend.com/v1/traces",
-```
-
-### Follow OpenTelemetry Semantic Conventions
-
-Use standard attribute names for consistency:
-
-```typescript
-import { SEMCONV, ADK_ATTRS } from "@iqai/adk";
-
-span.setAttribute(SEMCONV.GEN_AI_REQUEST_MODEL, "gpt-4");
-span.setAttribute(ADK_ATTRS.SESSION_ID, sessionId);
-```
-
-### Add Business Context with Custom Attributes
-
-Include custom attributes relevant to your domain:
-
-```typescript
-resourceAttributes: {
-  "deployment.name": "production",
-  "team": "platform",
-  "region": "us-east-1",
-  "customer.tier": "enterprise",
+// ❌ Never hardcode credentials
+otlpHeaders: {
+  "api-key": "sk-abc123...",
 },
 ```
 
-### Record Exceptions in Catch Blocks
+## Structured Custom Attributes
 
-Always record exceptions with context:
-
-```typescript
-try {
-  await riskyOperation();
-} catch (error) {
-  telemetryService.recordException(error as Error, {
-    "error.context": "data_validation",
-    "error.severity": "high",
-  });
-  throw error;
-}
-```
-
-### Create Focused Spans
-
-Create separate spans for distinct operations:
+Add business context to every span via `resourceAttributes`. These appear on all spans and metrics from this process, making it straightforward to filter by deployment or team in your backend:
 
 ```typescript
-// ✅ Good - focused spans
-await telemetryService.withSpan("fetch_data", async () => {
-  return await fetchData();
-});
-
-await telemetryService.withSpan("process_data", async () => {
-  return await processData();
-});
-
-// ❌ Bad - one span for everything
-await telemetryService.withSpan("do_everything", async () => {
-  await fetchData();
-  await processData();
-  await saveData();
-});
-```
-
-### Set Up Alerts for Critical Metrics
-
-Create alerts for error rates and latency thresholds:
-
-- Error rate exceeds 5%
-- 95th percentile latency exceeds 2 seconds
-- Token usage exceeds budget
-- Sampling rate drops below threshold
-
-### Monitor Data Ingestion Costs
-
-Be aware of data ingestion costs for paid platforms. Use sampling and export intervals to control costs.
-
-### Configure Data Retention Policies
-
-Set appropriate retention policies in your observability backend:
-
-| Data Type | Recommended Retention       |
-| --------- | --------------------------- |
-| Traces    | 7–30 days                   |
-| Metrics   | 30–90 days                  |
-| Logs      | Per compliance requirements |
-
-### Test Locally Before Deploying
-
-Always test telemetry with Jaeger locally before deploying to production:
-
-```bash
-# Start Jaeger locally
-docker run -d --name jaeger -p 4318:4318 -p 16686:16686 jaegertracing/all-in-one:latest
-
-# Test your agent
-await telemetryService.initialize({
-  otlpEndpoint: "http://localhost:4318/v1/traces",
-});
-
-# View traces at http://localhost:16686
+resourceAttributes: {
+  "deployment.name": "us-east-1-prod",
+  "team": "platform",
+  "customer.tier": "enterprise",
+},
 ```
 
 ## Troubleshooting
 
 ### No Traces Appearing
 
-**Check endpoint URL:**
+Verify the endpoint is reachable:
 
 ```bash
-# Verify endpoint is correct and reachable
-curl -X POST https://your-backend.com/v1/traces
+curl -X POST https://your-backend.com/v1/traces \
+  -H "Content-Type: application/json" \
+  -d '{}'
 ```
 
-**Verify backend is running:**
+Check that the OTLP receiver is running:
 
 ```bash
-# For Jaeger
-docker ps | grep jaeger
-
-# Check logs
+docker ps | grep jaeger   # or tempo, otel-collector, etc.
 docker logs jaeger
 ```
 
-**Enable debug logging:**
+Enable OpenTelemetry diagnostic logging to see what the SDK is doing:
 
 ```typescript
 import { diag, DiagConsoleLogger, DiagLogLevel } from "@opentelemetry/api";
@@ -338,144 +205,82 @@ await telemetryService.initialize({
 });
 ```
 
-**Check network connectivity:**
-
-```bash
-# Test connection to OTLP endpoint
-nc -zv your-backend.com 4318
-```
-
 ### High Overhead
 
-If telemetry is causing performance issues:
-
-**Reduce sampling ratio:**
+Reduce sampling and content capture:
 
 ```typescript
-samplingRatio: 0.05, // Sample only 5% of traces
-```
-
-**Disable auto-instrumentation:**
-
-```typescript
+samplingRatio: 0.05,           // 5% sampling
+captureMessageContent: false,  // no content in spans
 enableAutoInstrumentation: false,
+metricExportIntervalMs: 600000, // 10-minute metric interval
 ```
-
-**Increase export interval:**
-
-```typescript
-metricExportIntervalMs: 600000, // Export every 10 minutes
-```
-
-**Disable content capture:**
-
-```typescript
-captureMessageContent: false,
-```
-
-### Content Not Captured
-
-If you need content for debugging but it's not appearing:
-
-**Check environment variable:**
-
-```bash
-echo $ADK_CAPTURE_MESSAGE_CONTENT
-# Should be 'true' or unset for content capture
-```
-
-**Explicitly enable in configuration:**
-
-```typescript
-captureMessageContent: true,
-```
-
-### Connection Issues
-
-**Verify API keys have proper permissions:**
-
-```bash
-# Test API key with curl
-curl -H "api-key: $OTEL_API_KEY" https://your-backend.com/v1/traces
-```
-
-**Check firewall rules allow outbound connections:**
-
-```bash
-# Check if port is accessible
-telnet your-backend.com 4318
-```
-
-**Review header format requirements:**
-
-Some backends require specific header formats. Check your platform's documentation:
-
-```typescript
-// Datadog example
-otlpHeaders: {
-  "DD-API-KEY": process.env.DD_API_KEY,
-},
-
-// Honeycomb example
-otlpHeaders: {
-  "x-honeycomb-team": process.env.HONEYCOMB_API_KEY,
-  "x-honeycomb-dataset": "my-dataset",
-},
-```
-
-### Traces Contain Sensitive Data
-
-If you accidentally captured sensitive data:
-
-1. **Immediately disable content capture:**
-
-   ```bash
-   export ADK_CAPTURE_MESSAGE_CONTENT=false
-   ```
-
-2. **Contact your observability platform** to purge affected traces
-
-3. **Review your data retention policies** and ensure proper access controls
 
 ### Metrics Not Appearing
 
-**Verify metrics endpoint:**
+ADK-TS derives the metrics endpoint from the traces endpoint by replacing `/v1/traces` with `/v1/metrics`. If your traces endpoint does not contain `/v1/traces`, metrics will not export correctly.
 
-ADK-TS automatically converts trace endpoint to metrics endpoint:
+Also check that your backend supports OTLP metrics ingestion — Jaeger does not. Use Grafana/Tempo, Datadog, or a Prometheus-backed collector for metrics.
 
+Metrics are exported on a timer, so wait for at least one full `metricExportIntervalMs` before checking the backend.
+
+### Content Not Appearing in Spans
+
+Check that `ADK_CAPTURE_MESSAGE_CONTENT` is not set to `false` in the environment, and that `captureMessageContent` is not set to `false` in the configuration object:
+
+```bash
+echo $ADK_CAPTURE_MESSAGE_CONTENT
+# Should print "true" or be empty
 ```
-http://localhost:4318/v1/traces → http://localhost:4318/v1/metrics
-```
 
-**Check backend supports metrics:**
+### Sensitive Data in Traces
 
-Jaeger only supports traces. Use Grafana/Tempo, Datadog, or Prometheus for metrics.
+If you accidentally shipped content to your backend:
 
-**Verify export interval hasn't expired:**
+1. Set `captureMessageContent: false` immediately and redeploy.
+2. Contact your observability platform to purge affected traces.
+3. Audit your data retention and access control policies.
 
-Metrics are exported at intervals. Wait for the configured `metricExportIntervalMs` before checking.
+## Alerts to Configure
 
-## Related Topics
+Set up these alerts in your observability backend to catch problems before users do:
+
+| Condition              | Suggested threshold |
+| ---------------------- | ------------------- |
+| Error rate             | > 5% over 5 minutes |
+| p95 agent latency      | > 5 seconds         |
+| p95 LLM latency        | > 10 seconds        |
+| Token usage per minute | > your budget cap   |
+
+## Data Retention Guidelines
+
+| Data    | Recommended retention       |
+| ------- | --------------------------- |
+| Traces  | 7–30 days                   |
+| Metrics | 30–90 days                  |
+| Logs    | Per compliance requirements |
+
+## Next Steps
 
 <Cards>
   <Card
     title="🚀 Getting Started"
-    description="Initialize telemetry for local development"
+    description="All initialization options and the debug in-memory exporter"
     href="/docs/framework/observability/getting-started"
-  />
-  <Card
-    title="🔍 Distributed Tracing"
-    description="Understand what gets traced and create custom spans"
-    href="/docs/framework/observability/tracing"
-  />
-  <Card
-    title="📊 Metrics"
-    description="Monitor agent performance with counters and histograms"
-    href="/docs/framework/observability/metrics"
   />
   <Card
     title="🔌 Platform Integrations"
     description="Connect to Jaeger, Grafana, Datadog, and other backends"
     href="/docs/framework/observability/integrations"
+  />
+  <Card
+    title="🔍 Distributed Tracing"
+    description="Custom spans, events, and semantic conventions"
+    href="/docs/framework/observability/tracing"
+  />
+  <Card
+    title="📊 Metrics"
+    description="Available metrics, custom recording, and dashboard queries"
+    href="/docs/framework/observability/metrics"
   />
 </Cards>

--- a/apps/docs/content/docs/framework/observability/production.mdx
+++ b/apps/docs/content/docs/framework/observability/production.mdx
@@ -119,10 +119,14 @@ Spans emitted before `initialize()` completes are not captured. Build your telem
 await telemetryService.initialize({
   /* config */
 });
-const agent = AgentBuilder.withModel("gemini-2.5-flash").buildLlm();
+const { runner } = await AgentBuilder.create("my-agent")
+  .withModel("gemini-2.5-flash")
+  .build();
 
 // ❌ Traces will be missing
-const agent = AgentBuilder.withModel("gemini-2.5-flash").buildLlm();
+const { runner } = await AgentBuilder.create("my-agent")
+  .withModel("gemini-2.5-flash")
+  .build();
 await telemetryService.initialize({
   /* config */
 });

--- a/apps/docs/content/docs/framework/observability/tracing.mdx
+++ b/apps/docs/content/docs/framework/observability/tracing.mdx
@@ -183,7 +183,17 @@ await telemetryService.initialize({
 });
 
 const sessionId = "session-abc";
-await AgentBuilder.withModel("gemini-2.5-flash").ask("Hello!");
+const { runner } = await AgentBuilder.create("my-agent")
+  .withModel("gemini-2.5-flash")
+  .build();
+
+for await (const _ of runner.runAsync({
+  userId: "user-1",
+  sessionId,
+  newMessage: { role: "user", parts: [{ text: "Hello!" }] },
+})) {
+  // consume events
+}
 
 const spans = telemetryService.getTracesForSession(sessionId);
 for (const span of spans) {

--- a/apps/docs/content/docs/framework/observability/tracing.mdx
+++ b/apps/docs/content/docs/framework/observability/tracing.mdx
@@ -1,326 +1,264 @@
 ---
 title: Distributed Tracing
-description: Track agent invocations, tool executions, and LLM calls with OpenTelemetry spans
+description: Understand what ADK-TS traces automatically, how to read the trace hierarchy, and how to add custom spans
 ---
 
 import { Cards, Card } from "fumadocs-ui/components/card";
 import { Callout } from "fumadocs-ui/components/callout";
+import { Mermaid } from "@/components/mdx/mermaid";
 
-ADK-TS automatically traces agent execution, tool usage, and LLM interactions. Every operation creates spans with rich metadata, giving you complete visibility into your agent's behavior.
+Every agent run, LLM request, and tool call in ADK-TS automatically creates an OpenTelemetry span. Spans are nested to reflect the real execution order, so a single trace shows the complete path from user input to final response — including which tools ran, in what order, and how long each LLM call took.
 
-## What Gets Traced
+## Automatic Trace Hierarchy
 
-The telemetry system automatically traces three main operation types: agent invocations, tool executions, and LLM calls.
+Each agent entry point calls `telemetryService.traceAsyncGenerator()` to wrap its execution in a span. LLM calls and tool calls do the same, creating a parent-child hierarchy:
 
-### Agent Invocations
+<Mermaid
+  chart={`
+flowchart TD
+    A["agent_run [research-agent] #1"] --> B["llm_generate [gemini-2.5-flash] #1"]
+    A --> C["execute_tool [search_web] #1"]
+    A --> D["llm_generate [gemini-2.5-flash] #2"]
+    B --> E["HTTP POST → generativelanguage.googleapis.com\nauto-instrumented"]
+    C --> F["HTTP GET → api.search.example.com\nauto-instrumented"]
+`}
+/>
 
-Every agent execution creates a trace span with:
+Auto-instrumented HTTP spans only appear when `enableAutoInstrumentation: true` is set during initialization.
 
-- **Operation**: `invoke_agent`
-- **Attributes**:
-  - `gen_ai.provider.name`: `iqai-adk`
-  - `gen_ai.operation.name`: `invoke_agent`
-  - `gen_ai.agent.name`: Agent name
-  - `gen_ai.conversation.id`: Session ID
-  - `adk.session.id`: Session ID
-  - `adk.user.id`: User ID (if available)
-  - `adk.environment`: Environment name
-- **Duration**: Complete execution time
+## Agent Spans
 
-**Example trace structure:**
+Each agent execution creates a span named `agent_run [agentName] #N`, where `N` increments with each nested agent call in the same invocation. The span carries these attributes:
 
-```
-agent_run [my-agent]
-├─ Attributes:
-│  ├─ gen_ai.provider.name: iqai-adk
-│  ├─ gen_ai.operation.name: invoke_agent
-│  ├─ gen_ai.agent.name: my-agent
-│  ├─ gen_ai.conversation.id: session-123
-│  ├─ adk.session.id: session-123
-│  ├─ adk.user.id: user-456
-│  └─ adk.environment: production
-└─ Duration: 2.5s
-```
+| Attribute                | Value                 |
+| ------------------------ | --------------------- |
+| `gen_ai.provider.name`   | `iqai-adk`            |
+| `gen_ai.operation.name`  | `invoke_agent`        |
+| `gen_ai.agent.name`      | Agent name            |
+| `gen_ai.agent.id`        | `agentName-sessionId` |
+| `gen_ai.conversation.id` | Session ID            |
+| `adk.session.id`         | Session ID            |
+| `adk.user.id`            | User ID (if set)      |
+| `adk.invocation.id`      | Invocation ID         |
+| `adk.environment`        | Environment name      |
 
-### Tool Executions
+When `captureMessageContent` is enabled, the span also receives `gen_ai.input.messages` and `gen_ai.output.messages` events with the full conversation content.
 
-Every tool call is traced with:
+## LLM Spans
 
-- **Operation**: `execute_tool`
-- **Attributes**:
-  - `gen_ai.provider.name`: `iqai-adk`
-  - `gen_ai.operation.name`: `execute_tool`
-  - `gen_ai.tool.name`: Tool name
-  - `gen_ai.tool.type`: Tool type/class
-  - `adk.tool.args`: Tool arguments (if content capture enabled)
-  - `adk.tool.response`: Tool response (if content capture enabled)
-- **Duration**: Tool execution time
+Each LLM request creates a span named `llm_generate [modelName] #N` for blocking calls or `llm_stream [modelName] #N` for streaming. These spans follow the [OpenTelemetry GenAI semantic conventions](https://opentelemetry.io/docs/specs/semconv/gen-ai/):
 
-**Example trace structure:**
+| Attribute                        | Value                                                |
+| -------------------------------- | ---------------------------------------------------- |
+| `gen_ai.provider.name`           | Provider name (e.g. `openai`, `anthropic`, `google`) |
+| `gen_ai.operation.name`          | `chat`                                               |
+| `gen_ai.request.model`           | Model name                                           |
+| `gen_ai.request.max_tokens`      | Max output tokens                                    |
+| `gen_ai.request.temperature`     | Temperature                                          |
+| `gen_ai.response.id`             | Response ID from the provider                        |
+| `gen_ai.response.finish_reasons` | Array of finish reasons                              |
+| `gen_ai.output.type`             | `text` or `json`                                     |
+| `gen_ai.usage.input_tokens`      | Prompt token count                                   |
+| `gen_ai.usage.output_tokens`     | Completion token count                               |
+| `adk.llm.model`                  | Model name                                           |
+| `adk.session.id`                 | Session ID                                           |
 
-```
-execute_tool search_web
-├─ Attributes:
-│  ├─ gen_ai.provider.name: iqai-adk
-│  ├─ gen_ai.operation.name: execute_tool
-│  ├─ gen_ai.tool.name: search_web
-│  ├─ gen_ai.tool.type: SearchTool
-│  ├─ adk.tool.args: {"query": "OpenTelemetry"}
-│  └─ adk.tool.response: {"results": [...]}
-└─ Duration: 450ms
-```
+When `captureMessageContent` is enabled, the span also receives `gen_ai.input.messages` and `gen_ai.output.messages` attributes containing the full prompt and response, plus `gen_ai.system_instructions` if a system prompt was set.
 
-### LLM Calls
+## Tool Spans
 
-Every LLM request is traced with:
+Each tool call creates a span named `execute_tool [toolName] #N`:
 
-- **Span Name**: `llm_generate [model]` or `llm_stream [model]` (for streaming)
-- **Operation**: `chat` (OpenTelemetry GenAI semantic convention)
-- **Attributes**:
-  - `gen_ai.provider.name`: Provider name (e.g., `openai`, `anthropic`, `google`)
-  - `gen_ai.operation.name`: `chat`
-  - `gen_ai.request.model`: Model name
-  - `gen_ai.request.max_tokens`: Maximum tokens
-  - `gen_ai.request.temperature`: Temperature setting
-  - `gen_ai.usage.input_tokens`: Input token count
-  - `gen_ai.usage.output_tokens`: Output token count
-- **Events** (if content capture enabled):
-  - `gen_ai.content.prompt`: Full prompt content
-  - `gen_ai.content.completion`: Full completion content
-- **Duration**: LLM call duration
+| Attribute                 | Value            |
+| ------------------------- | ---------------- |
+| `gen_ai.provider.name`    | `iqai-adk`       |
+| `gen_ai.operation.name`   | `execute_tool`   |
+| `gen_ai.tool.name`        | Tool name        |
+| `gen_ai.tool.description` | Tool description |
+| `gen_ai.tool.type`        | Tool class name  |
+| `gen_ai.tool.call.id`     | Tool call ID     |
+| `adk.tool.name`           | Tool name        |
+| `adk.session.id`          | Session ID       |
 
-**Example trace structure:**
-
-```
-llm_generate [gpt-4]
-├─ Attributes:
-│  ├─ gen_ai.provider.name: openai
-│  ├─ gen_ai.operation.name: chat
-│  ├─ gen_ai.request.model: gpt-4
-│  ├─ gen_ai.request.max_tokens: 1024
-│  ├─ gen_ai.request.temperature: 0.7
-│  ├─ gen_ai.usage.input_tokens: 150
-│  └─ gen_ai.usage.output_tokens: 75
-├─ Events:
-│  ├─ gen_ai.content.prompt: [...]
-│  └─ gen_ai.content.completion: [...]
-└─ Duration: 1.8s
-```
-
-## Trace Hierarchy
-
-Traces form a hierarchical structure showing the complete execution flow:
-
-```
-agent_run [research-agent] (5.2s)
-├─ llm_generate [gpt-4] (1.8s)
-│  └─ HTTP POST to api.openai.com (1.7s) [auto-instrumented]
-├─ execute_tool search_web (450ms)
-│  └─ HTTP GET to google.com (420ms) [auto-instrumented]
-├─ execute_tool summarize_text (320ms)
-└─ llm_generate [gpt-4] (1.5s)
-   └─ HTTP POST to api.openai.com (1.4s) [auto-instrumented]
-```
-
-This hierarchy shows:
-
-- Parent-child relationships between operations
-- Nested tool calls and LLM requests
-- Auto-instrumented HTTP calls
-- Complete timing information
-
-## Viewing Traces
-
-ADK-TS sends traces via OTLP to any compatible observability backend. You'll need to set up a trace viewer separately. Popular options include Jaeger (for local development), Grafana, Datadog, New Relic, and Honeycomb.
-
-<Callout type="info" title="No Built-in Viewer">
-  ADK-TS does not include a built-in trace viewer. You need to set up an
-  external observability platform to view traces. See the [Platform
-  Integrations](/docs/framework/observability/integrations) guide for setup
-  instructions.
-</Callout>
-
-### Using Jaeger (Local Development)
-
-Jaeger is a popular open-source option for local development. It allows you to visualize and analyze traces in a user-friendly interface.
-
-1. **Set up Jaeger**: See the [Platform Integrations](/docs/framework/observability/integrations#jaeger) guide for Docker setup instructions
-2. **Open Jaeger UI**: Navigate to `http://localhost:16686`
-3. **Select Service**: Choose your service name from the dropdown
-4. **Find Traces**: Click "Find Traces" to see all traces
-5. **Explore Details**: Click on any trace to see:
-   - Complete span hierarchy
-   - Attributes and metadata
-   - Timing information
-   - Related spans
-
-Jaeger's search features allow you to filter by service name or tags/attributes, search by operation name, and find traces within specific time ranges.
+When `captureMessageContent` is enabled, the span additionally carries `gen_ai.tool.call.arguments` and `gen_ai.tool.call.result` with the full serialized arguments and response.
 
 ## Custom Spans
 
-Custom spans allow you to create your own trace segments for specific operations, providing detailed insights into your application's behavior.
+Wrap any async operation in a span using `telemetryService.withSpan()`. The callback receives the live `Span` object so you can add attributes mid-execution:
 
 ```typescript
 import { telemetryService } from "@iqai/adk";
 
-// Execute function within a traced span
-const result = await telemetryService.withSpan(
-  "custom_operation",
+const report = await telemetryService.withSpan(
+  "generate_report",
   async span => {
-    span.setAttribute("custom.attribute", "value");
+    span.setAttribute("report.type", "weekly");
+    span.setAttribute("report.userId", "user-123");
 
-    // Your work here
-    const result = await doSomething();
+    const data = await fetchReportData("user-123");
+    span.setAttribute("report.recordCount", data.length);
 
-    return result;
+    return compileReport(data);
   },
-  {
-    "operation.type": "data_processing",
-    "operation.version": "2.0",
-  },
+  { "report.version": "2" },
 );
 ```
 
-## Async Generator Tracing
+The initial attributes object (third argument) is set before the callback runs. The span is automatically closed and marked OK or ERROR depending on whether the callback throws.
 
-Trace async generators for streaming operations:
+## Tracing Async Generators
 
-```typescript
-async function* myGenerator() {
-  yield 1;
-  yield 2;
-  yield 3;
-}
-
-// Wrap with tracing
-const tracedGenerator = telemetryService.traceAsyncGenerator(
-  "my_operation",
-  myGenerator(),
-  {
-    "generator.type": "number_stream",
-  },
-);
-
-for await (const value of tracedGenerator) {
-  console.log(value); // Traced within span
-}
-```
-
-## Adding Events to Spans
-
-Add events to the active span for additional context:
+Streaming operations that use async generators can be traced with `traceAsyncGenerator()`. The span stays open for the duration of the generator and closes when it finishes or throws:
 
 ```typescript
 import { telemetryService } from "@iqai/adk";
 
-telemetryService.addEvent("user_action", {
-  "action.type": "button_click",
-  "action.target": "submit",
+async function* generateItems() {
+  yield "item-1";
+  yield "item-2";
+  yield "item-3";
+}
+
+const traced = telemetryService.traceAsyncGenerator(
+  "generate_items",
+  generateItems(),
+  { "generator.source": "database" },
+);
+
+for await (const item of traced) {
+  console.log(item);
+}
+```
+
+## Adding Events and Attributes to the Active Span
+
+Events are timestamped annotations attached to the currently active span. Use them to mark specific moments during a longer operation:
+
+```typescript
+import { telemetryService } from "@iqai/adk";
+
+telemetryService.addEvent("cache_miss", {
+  "cache.key": "user:123:preferences",
+  "cache.ttl": 300,
+});
+```
+
+To set attributes on the active span without creating an event:
+
+```typescript
+telemetryService.setActiveSpanAttributes({
+  "processing.stage": "normalization",
+  "processing.inputSize": 4096,
 });
 ```
 
 ## Recording Exceptions
 
-Record exceptions with context:
+Exceptions recorded on a span appear as structured events in the trace backend and set the span status to ERROR:
 
 ```typescript
 import { telemetryService } from "@iqai/adk";
 
 try {
-  await riskyOperation();
+  await callExternalApi();
 } catch (error) {
   telemetryService.recordException(error as Error, {
-    "error.context": "data_validation",
-    "error.severity": "high",
+    "error.context": "external_api_call",
+    "error.service": "payments",
   });
   throw error;
 }
 ```
 
-## Semantic Conventions
+## Debug Mode: Reading Spans In-Process
 
-ADK-TS follows OpenTelemetry GenAI semantic conventions for consistent tracing across AI systems.
-
-### Standard Attributes (gen_ai.\*)
+When `debug: true` is set during initialization, spans are also written to an in-memory exporter. Call `getTraces()` or `getTracesForSession()` to inspect them without a running backend:
 
 ```typescript
-import { SEMCONV } from "@iqai/adk";
+import { telemetryService, AgentBuilder } from "@iqai/adk";
 
-// Provider identification
-SEMCONV.GEN_AI_PROVIDER_NAME; // "gen_ai.provider.name"
+await telemetryService.initialize({
+  appName: "my-agent-app",
+  debug: true,
+});
 
-// Operations
-SEMCONV.GEN_AI_OPERATION_NAME; // "gen_ai.operation.name"
+const sessionId = "session-abc";
+await AgentBuilder.withModel("gemini-2.5-flash").ask("Hello!");
 
-// Agents
-SEMCONV.GEN_AI_AGENT_NAME; // "gen_ai.agent.name"
-SEMCONV.GEN_AI_CONVERSATION_ID; // "gen_ai.conversation.id"
-
-// Tools
-SEMCONV.GEN_AI_TOOL_NAME; // "gen_ai.tool.name"
-SEMCONV.GEN_AI_TOOL_TYPE; // "gen_ai.tool.type"
-
-// LLM Requests
-SEMCONV.GEN_AI_REQUEST_MODEL; // "gen_ai.request.model"
-SEMCONV.GEN_AI_REQUEST_MAX_TOKENS; // "gen_ai.request.max_tokens"
-
-// Token Usage
-SEMCONV.GEN_AI_USAGE_INPUT_TOKENS; // "gen_ai.usage.input_tokens"
-SEMCONV.GEN_AI_USAGE_OUTPUT_TOKENS; // "gen_ai.usage.output_tokens"
+const spans = telemetryService.getTracesForSession(sessionId);
+for (const span of spans) {
+  console.log(span.name, span.attributes);
+}
 ```
 
-### ADK-TS-Specific Attributes (adk.\*)
+`getTraces()` returns all spans across all sessions. Both return `ReadableSpan[]` from `@opentelemetry/sdk-trace-base`.
+
+## Semantic Conventions Reference
+
+Use the exported constants when setting custom attributes to stay consistent with ADK-TS internals:
 
 ```typescript
-import { ADK_ATTRS } from "@iqai/adk";
+import { SEMCONV, ADK_ATTRS, OPERATIONS } from "@iqai/adk";
 
-// Session and context
+// Standard OpenTelemetry GenAI attributes
+SEMCONV.GEN_AI_PROVIDER_NAME; // "gen_ai.provider.name"
+SEMCONV.GEN_AI_OPERATION_NAME; // "gen_ai.operation.name"
+SEMCONV.GEN_AI_AGENT_NAME; // "gen_ai.agent.name"
+SEMCONV.GEN_AI_CONVERSATION_ID; // "gen_ai.conversation.id"
+SEMCONV.GEN_AI_TOOL_NAME; // "gen_ai.tool.name"
+SEMCONV.GEN_AI_REQUEST_MODEL; // "gen_ai.request.model"
+SEMCONV.GEN_AI_USAGE_INPUT_TOKENS; // "gen_ai.usage.input_tokens"
+SEMCONV.GEN_AI_USAGE_OUTPUT_TOKENS; // "gen_ai.usage.output_tokens"
+
+// ADK-TS-specific attributes
 ADK_ATTRS.SESSION_ID; // "adk.session.id"
 ADK_ATTRS.USER_ID; // "adk.user.id"
 ADK_ATTRS.INVOCATION_ID; // "adk.invocation.id"
-
-// Content
 ADK_ATTRS.TOOL_ARGS; // "adk.tool.args"
 ADK_ATTRS.TOOL_RESPONSE; // "adk.tool.response"
 ADK_ATTRS.LLM_REQUEST; // "adk.llm.request"
 ADK_ATTRS.LLM_RESPONSE; // "adk.llm.response"
+
+// Operation name constants
+OPERATIONS.INVOKE_AGENT; // "invoke_agent"
+OPERATIONS.EXECUTE_TOOL; // "execute_tool"
+OPERATIONS.CHAT; // "chat"
+OPERATIONS.TRANSFER_AGENT; // "transfer_agent"
+OPERATIONS.SEARCH_MEMORY; // "search_memory"
 ```
 
 ## Auto-Instrumentation
 
-When `enableAutoInstrumentation: true` is set, the telemetry system automatically instruments:
+When `enableAutoInstrumentation: true` is set, the OpenTelemetry Node SDK instruments outbound HTTP, Express, and NestJS automatically. These appear as child spans under the LLM or tool span that triggered them:
 
-| Operation              | Description                           |
-| ---------------------- | ------------------------------------- |
-| HTTP/HTTPS calls       | All outbound HTTP requests are traced |
-| Database queries       | Database operations are captured      |
-| File system operations | File I/O is traced                    |
-| DNS lookups            | DNS resolution is tracked             |
+| What gets traced    | Notes                                  |
+| ------------------- | -------------------------------------- |
+| Outbound HTTP/HTTPS | All `node:http` and `node:https` calls |
+| Express routes      | Incoming request handling              |
+| NestJS controllers  | Route and middleware execution         |
 
-These appear as child spans in your traces, providing visibility into external dependencies.
-
-<Callout type="info" title="Auto-Instrumentation is Opt-In">
-  Auto-instrumentation is disabled by default. Enable it with
-  `enableAutoInstrumentation: true` if you want to trace HTTP calls, database
-  queries, and other external operations.
+<Callout type="info" title="Opt-in">
+  Auto-instrumentation is off by default (`enableAutoInstrumentation: false`).
+  Enable it when you want visibility into the HTTP calls your tools make to
+  external APIs.
 </Callout>
 
-## Related Topics
+## Next Steps
 
 <Cards>
   <Card
     title="📊 Metrics"
-    description="Monitor agent performance with counters and histograms"
+    description="Counters and histograms that complement your traces"
     href="/docs/framework/observability/metrics"
   />
   <Card
     title="🔌 Platform Integrations"
-    description="Connect to Jaeger, Grafana, Datadog, and other backends"
+    description="View traces in Jaeger, Grafana, Datadog, and other backends"
     href="/docs/framework/observability/integrations"
   />
   <Card
-    title="🔒 Production Deployment"
-    description="Privacy controls, performance tuning, and best practices"
+    title="🔒 Production"
+    description="Sampling, privacy controls, and production best practices"
     href="/docs/framework/observability/production"
   />
 </Cards>


### PR DESCRIPTION
## Summary

- Rewrote all six observability pages (`index`, `getting-started`, `tracing`, `metrics`, `integrations`, `production`) for accuracy, completeness, and consistency
- Fixed a factual bug in `integrations.mdx`: a `Callout` incorrectly claimed ADK-TS auto-appends `/v1/traces` to the endpoint — the source uses the value as-is; all Datadog endpoint examples updated to include the full path
- Corrected `resourceAttributes` type from `Record<string, string>` to `Record<string, string | number | boolean>` to match the `TelemetryConfig` interface
- Documented the previously undocumented `debug` mode (`debug: true`), `getTraces()`, and `getTracesForSession()` in both `getting-started` and `tracing`
- Added missing `recordToolDuration()`, `recordLlmDuration()`, and `recordError()` methods to `metrics`
- Updated all span name examples to include the `#N` index suffix (e.g. `agent_run [research-agent] #1`) to match the actual source in `base-agent.ts`
- Removed all references to deprecated `gen_ai.content.prompt` / `gen_ai.content.completion` attributes; replaced with the current `gen_ai.input.messages` / `gen_ai.output.messages`
- Replaced unsupported `promql` syntax highlighter with `text` to fix build error
- Converted all headings to Title Case throughout the section

## Test plan

- [ ] Docs site builds without errors (`pnpm build:docs`)
- [ ] All six observability pages render correctly in the browser
- [ ] Mermaid diagrams on `index` and `tracing` render correctly
- [ ] Tabs, Callouts, and Cards render on all pages

🤖 Generated with [Claude Code](https://claude.com/claude-code)